### PR TITLE
chore: add issue templates, PR template, CODEOWNERS, FUNDING, and label/project docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# DragonShout Code Owners
+# These users will be automatically requested for review on PRs
+
+* @Xerrion

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: Xerrion
+ko_fi: Xerrion

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: Bug Report
+description: Report a bug with DragonShout
+title: "[Bug]: "
+labels:
+  - C-Bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Numbered steps to trigger the bug
+      placeholder: |
+        1. Open the game
+        2. Do something specific
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happens (include errors)
+    validations:
+      required: true
+  - type: dropdown
+    id: wow-version
+    attributes:
+      label: WoW Version
+      description: Which version of World of Warcraft are you playing?
+      options:
+        - Retail
+        - MoP Classic
+        - TBC Anniversary
+    validations:
+      required: true
+  - type: input
+    id: dragonshout-version
+    attributes:
+      label: DragonShout Version
+      description: 'Version number or "latest"'
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Screenshots, error logs, addon list
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Suggest a new feature or improvement for DragonShout
+title: "[Feature]: "
+labels:
+  - C-Feature
+assignees: []
+body:
+  - type: textarea
+    id: problem-motivation
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the desired feature or API
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've considered
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Examples, references, mockups
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Description
+
+<!-- Describe your changes in detail. What does this PR do? -->
+
+## Type of Change
+
+<!-- Check the relevant option(s) -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (non-breaking change that improves code quality)
+- [ ] Documentation update
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Related Issues
+
+<!-- Link any related issues. Use "Fixes #123" to auto-close -->
+
+## Testing
+
+<!-- Describe the testing you performed -->
+
+- [ ] Luacheck passes (`luacheck .`)
+- [ ] Tested in-game manually
+- [ ] WoW version(s) tested on: <!-- e.g., TBC Anniversary, Retail -->
+
+## Screenshots
+
+<!-- If your changes affect the UI, add screenshots here. Remove this section if not applicable. -->
+
+## Checklist
+
+- [ ] My code follows the project's code style (4-space indent, 120 char lines)
+- [ ] I have tested my changes in-game
+- [ ] Luacheck reports no warnings
+- [ ] My commits follow [conventional commit](https://www.conventionalcommits.org/) format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,47 @@ DragonShout/                    (repo root)
 3. `SPELL_AURA_REFRESH` does NOT have an amount field at idx 16
 4. `CC_TYPE[spellId] ~= nil` is the guard for CC detection in AuraListener - no separate IS_CC_SPELL table exists
 5. `C_ChatInfo.SendChatMessage` is Retail 11.2+ only - fallback to `SendChatMessage`
+
+## Labels
+
+### DragonShout Labels
+
+| Label | Description |
+| --- | --- |
+| **Category** | |
+| `C-Bug` | Unexpected or incorrect behavior |
+| `C-Feature` | New feature or enhancement |
+| `C-Performance` | Speed, memory, or efficiency improvement |
+| `C-Usability` | UX improvement, better defaults, polish |
+| `C-Code-Quality` | Refactor, cleanup, technical debt |
+| `C-Documentation` | Docs, README, AGENTS.md, comments |
+| `C-Localization` | Translation and locale support |
+| **Area** | |
+| `A-Core` | Addon lifecycle, slash commands, minimap icon |
+| `A-Announcer` | Message formatting, throttling, channel resolution |
+| `A-Listeners` | Combat log listeners (interrupt, CC/aura, dispel) |
+| `A-Config` | Config schema, defaults, AceDB |
+| `A-Options` | DragonShout_Options companion addon |
+| `A-Appearance` | Visual styling, fonts, textures |
+| `A-Localization` | Locale files, translations |
+| `A-CI` | GitHub workflows, packaging, CI/CD |
+| **Difficulty** | |
+| `D-Good-First-Issue` | Good for newcomers |
+| `D-Straightforward` | Clear scope, low risk |
+| `D-Complex` | Multiple files or systems involved |
+| `D-Expert` | Deep WoW API knowledge or tricky edge cases |
+| **Platform** | |
+| `P-Retail` | Retail (11.x / 12.x) |
+| `P-TBC-Anniversary` | TBC Anniversary Classic |
+| `P-MoP-Classic` | Mists of Pandaria Classic |
+| `P-All-Versions` | Affects all supported versions |
+| **Status** | |
+| `S-Needs-Triage` | New issue awaiting review |
+
+## GitHub Projects
+
+- DragonShout has two projects: **DragonShout - Bugs** (project #10) and **DragonShout - Feature Requests** (project #11)
+- Route by label: `C-Bug` -> Bugs project, `C-Feature` -> Feature Requests project
+- Status columns: **To triage -> Backlog -> Ready -> In progress -> In review -> Done**
+- Move status as work progresses: To triage (filed) -> Backlog (scoped) -> In progress (branch created) -> In review (PR open) -> Done (merged)
+


### PR DESCRIPTION
## Description

Brings DragonShout's GitHub repo setup up to parity with DragonLoot and DragonToast.

## Changes

- Add  and 
- Add  (blank issues disabled)
- Add 
- Add 
- Add 
- Update  with full label taxonomy and GitHub Projects documentation

## Notes

Labels (C-*, A-*, D-*, P-*, S-*) and GitHub Projects (#10 Bugs, #11 Feature Requests) were created directly via Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` CLI and are already live on the repo.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established standardized GitHub issue templates for bug reports and feature requests with automatic categorization.
  * Added pull request template with contribution guidelines, testing checklist, and code quality requirements.
  * Configured issue labeling system and GitHub Projects structure for streamlined workflow management.
  * Added repository funding and code ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->