### PR TITLE
fix: wrap long debug print lines to pass luacheck W631

### DIFF
--- a/DragonShout/Listeners/AuraListener.lua
+++ b/DragonShout/Listeners/AuraListener.lua
@@ -155,7 +155,8 @@ function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, d
     local ccType = CC_TYPE[spellId]
 
     if destGUID == ns.playerGUID then
-        ns.DebugPrint(string_format("AuraListener: CC on player - spellId=%s type=%s", tostring(spellId), tostring(ccType)))
+        ns.DebugPrint(string_format("AuraListener: CC on player - spellId=%s type=%s",
+            tostring(spellId), tostring(ccType)))
         local categoryConfig = db.profile.ccOnYou
         if categoryConfig[ccType] ~= false then
             local typeLabel = CC_TYPE_LABEL[ccType] or ""
@@ -173,7 +174,8 @@ function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, d
     end
 
     if sourceGUID == ns.playerGUID then
-        ns.DebugPrint(string_format("AuraListener: CC applied by player - spellId=%s target=%s", tostring(spellId), tostring(destName)))
+        ns.DebugPrint(string_format("AuraListener: CC applied by player - spellId=%s target=%s",
+            tostring(spellId), tostring(destName)))
         ns.Announcer.Announce("ccApplied", spellId, {
             spell = spellName,
             target = destName,

--- a/DragonShout/Listeners/DispelListener.lua
+++ b/DragonShout/Listeners/DispelListener.lua
@@ -28,7 +28,8 @@ function ns.DispelListener.OnDispel(sourceGUID, sourceName, _, _, _, destName, _
         return
     end
     if sourceGUID ~= ns.playerGUID then
-        ns.DebugPrint(string_format("DispelListener: sourceGUID %s != playerGUID %s", tostring(sourceGUID), tostring(ns.playerGUID)))
+        ns.DebugPrint(string_format("DispelListener: sourceGUID %s != playerGUID %s",
+            tostring(sourceGUID), tostring(ns.playerGUID)))
         return
     end
 
@@ -41,5 +42,6 @@ function ns.DispelListener.OnDispel(sourceGUID, sourceName, _, _, _, destName, _
         extraSpell = extraSpellName,
     })
 
-    ns.DebugPrint(string_format("DispelListener: dispel detected spellId=%s target=%s", tostring(spellId), tostring(destName)))
+    ns.DebugPrint(string_format("DispelListener: dispel detected spellId=%s target=%s",
+        tostring(spellId), tostring(destName)))
 end

--- a/DragonShout/Listeners/InterruptListener.lua
+++ b/DragonShout/Listeners/InterruptListener.lua
@@ -44,7 +44,8 @@ function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destN
         return
     end
     if sourceGUID ~= ns.playerGUID then
-        ns.DebugPrint(string_format("InterruptListener: sourceGUID %s != playerGUID %s", tostring(sourceGUID), tostring(ns.playerGUID)))
+        ns.DebugPrint(string_format("InterruptListener: sourceGUID %s != playerGUID %s",
+            tostring(sourceGUID), tostring(ns.playerGUID)))
         return
     end
 
@@ -58,5 +59,6 @@ function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destN
         extraSpell = extraSpellName,
     })
 
-    ns.DebugPrint(string_format("InterruptListener: interrupt detected spellId=%s target=%s", tostring(spellId), tostring(destName)))
+    ns.DebugPrint(string_format("InterruptListener: interrupt detected spellId=%s target=%s",
+        tostring(spellId), tostring(destName)))
 end


### PR DESCRIPTION
## Description

Wraps 6 over-length `string_format` debug print lines in the listener files onto continuation lines. No logic changes -- formatting only.

Fixes luacheck W631 (line > 120 chars) in:
- `Listeners/AuraListener.lua` (lines 158, 176)
- `Listeners/DispelListener.lua` (lines 31, 44)
- `Listeners/InterruptListener.lua` (lines 47, 61)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

N/A

## Testing

- [x] Luacheck passes (`luacheck .`)

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [x] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal debug logging statements across listener modules for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->