### PR TITLE
feat: add per-type Solo/Group/Raid channel selection (#5)

### DIFF
--- a/DragonShout/Core/Announcer.lua
+++ b/DragonShout/Core/Announcer.lua
@@ -26,6 +26,21 @@ local wipe = wipe
 -------------------------------------------------------------------------------
 
 ns.Announcer = {}
+
+-------------------------------------------------------------------------------
+-- Group context helper
+-- Returns "raid", "group", or "solo" based on current group membership.
+-------------------------------------------------------------------------------
+
+local function GetGroupContext()
+    if LE_PARTY_CATEGORY_INSTANCE and IsInGroup(LE_PARTY_CATEGORY_INSTANCE) then
+        return "raid"
+    end
+    if IsInRaid() then return "raid" end
+    if IsInGroup() then return "group" end
+    return "solo"
+end
+
 local lastAnnounceTimes = {}
 
 -------------------------------------------------------------------------------
@@ -34,23 +49,19 @@ local lastAnnounceTimes = {}
 
 local function ResolveChannel(category)
     local db = ns.Addon and ns.Addon.db
-    if not db then return "SAY" end
+    if not db then return "LOCAL" end
 
-    local channelSetting = db.profile[category] and db.profile[category].channel or "AUTO"
+    local categoryConfig = db.profile[category]
+    if not categoryConfig then return "LOCAL" end
 
-    if channelSetting ~= "AUTO" then
-        return channelSetting
+    local ctx = GetGroupContext()
+    if ctx == "raid" then
+        return categoryConfig.channelRaid or "RAID"
+    elseif ctx == "group" then
+        return categoryConfig.channelGroup or "PARTY"
+    else
+        return categoryConfig.channelSolo or "LOCAL"
     end
-
-    if LE_PARTY_CATEGORY_INSTANCE and IsInGroup(LE_PARTY_CATEGORY_INSTANCE) then
-        return "INSTANCE_CHAT"
-    elseif IsInRaid() then
-        return "RAID"
-    elseif IsInGroup() then
-        return "PARTY"
-    end
-
-    return "SAY"
 end
 
 -------------------------------------------------------------------------------
@@ -71,6 +82,10 @@ end
 
 local function SendMessage(channel, msg)
     if not msg or msg == "" then return end
+    if channel == "LOCAL" then
+        ns.Print(msg)
+        return
+    end
     SendChatMessage(msg, channel)
 end
 
@@ -149,7 +164,14 @@ function ns.Announcer.AnnounceCustom(spellId, tokens)
             if (now - lastTime) >= throttleDuration then
                 local channel = entry.channel or "AUTO"
                 if channel == "AUTO" then
-                    channel = ResolveChannel("customSpells")
+                    local ctx = GetGroupContext()
+                    if ctx == "raid" then
+                        channel = "RAID"
+                    elseif ctx == "group" then
+                        channel = "PARTY"
+                    else
+                        channel = "LOCAL"
+                    end
                 end
 
                 local msg = ApplyTemplate(entry.template or "", tokens)

--- a/DragonShout/Core/Config.lua
+++ b/DragonShout/Core/Config.lua
@@ -23,13 +23,17 @@ local defaults = {
 
         interrupts = {
             enabled = true,
-            channel = "AUTO",
+            channelSolo = "LOCAL",
+            channelGroup = "PARTY",
+            channelRaid = "RAID",
             template = "Interrupted {target}'s {extraSpell} with {spell}!",
         },
 
         ccOnYou = {
             enabled = true,
-            channel = "AUTO",
+            channelSolo = "LOCAL",
+            channelGroup = "PARTY",
+            channelRaid = "RAID",
             template = "{type} for {duration}s!",
             typeTemplates = {
                 silence   = "Silenced for {duration}s!",
@@ -49,13 +53,17 @@ local defaults = {
 
         ccApplied = {
             enabled = true,
-            channel = "AUTO",
+            channelSolo = "LOCAL",
+            channelGroup = "PARTY",
+            channelRaid = "RAID",
             template = "CC'd {target} with {spell}!",
         },
 
         dispels = {
             enabled = true,
-            channel = "AUTO",
+            channelSolo = "LOCAL",
+            channelGroup = "PARTY",
+            channelRaid = "RAID",
             template = "Dispelled {extraSpell} from {target}!",
         },
 
@@ -104,6 +112,25 @@ local function MigrateProfile(db)
         end
 
         profile.schemaVersion = 2
+    end
+
+    if version < 3 then
+        local categories = { "interrupts", "ccOnYou", "ccApplied", "dispels" }
+        for _, cat in ipairs(categories) do
+            local cfg = profile[cat]
+            if cfg and cfg.channel then
+                local old = cfg.channel
+                local solo  = (old == "AUTO" or old == nil) and "LOCAL" or old
+                local group = (old == "AUTO" or old == nil) and "PARTY" or old
+                local raid  = (old == "AUTO" or old == nil) and "RAID"  or old
+                cfg.channelSolo  = cfg.channelSolo  or solo
+                cfg.channelGroup = cfg.channelGroup or group
+                cfg.channelRaid  = cfg.channelRaid  or raid
+                cfg.channel = nil
+            end
+        end
+        version = 3 -- luacheck: ignore 311/version (future migrations will read this)
+        profile.schemaVersion = 3
     end
 end
 

--- a/DragonShout/Core/SlashCommands.lua
+++ b/DragonShout/Core/SlashCommands.lua
@@ -25,7 +25,19 @@ local function YesNo(cond)
     return cond and ns.COLOR_GREEN .. L["Yes"] or ns.COLOR_RED .. L["No"]
 end
 
+local function PrintCategory(label, cfg)
+    print("  " .. label .. ": " .. YesNo(cfg.enabled)
+        .. ns.COLOR_RESET .. " | " .. L["Solo"] .. ": " .. tostring(cfg.channelSolo)
+        .. " " .. L["Group"] .. ": " .. tostring(cfg.channelGroup)
+        .. " " .. L["Raid"] .. ": " .. tostring(cfg.channelRaid))
+end
+
 local function PrintStatus()
+    if not (ns.Addon and ns.Addon.db) then
+        ns.Print(L["Addon not yet initialized."])
+        return
+    end
+
     local db = ns.Addon.db.profile
 
     print(ns.COLOR_GOLD .. L["--- DragonShout Status ---"] .. ns.COLOR_RESET)
@@ -36,14 +48,10 @@ local function PrintStatus()
     print("  " .. L["Version"] .. ": " .. ns.COLOR_WHITE .. (ns.IS_RETAIL and "Retail" or "Classic") .. ns.COLOR_RESET)
     print("  " .. L["Debug Mode"] .. ": " .. YesNo(ns._debugMode or db.debug))
     print("")
-    print("  " .. L["Interrupts"] .. ": " .. YesNo(db.interrupts.enabled)
-        .. ns.COLOR_RESET .. " | " .. L["Channel"] .. ": " .. db.interrupts.channel)
-    print("  " .. L["CC on You"] .. ": " .. YesNo(db.ccOnYou.enabled)
-        .. ns.COLOR_RESET .. " | " .. L["Channel"] .. ": " .. db.ccOnYou.channel)
-    print("  " .. L["CC Applied"] .. ": " .. YesNo(db.ccApplied.enabled)
-        .. ns.COLOR_RESET .. " | " .. L["Channel"] .. ": " .. db.ccApplied.channel)
-    print("  " .. L["Dispels"] .. ": " .. YesNo(db.dispels.enabled)
-        .. ns.COLOR_RESET .. " | " .. L["Channel"] .. ": " .. db.dispels.channel)
+    PrintCategory(L["Interrupts"], db.interrupts)
+    PrintCategory(L["CC on You"], db.ccOnYou)
+    PrintCategory(L["CC Applied"], db.ccApplied)
+    PrintCategory(L["Dispels"], db.dispels)
 end
 
 -------------------------------------------------------------------------------

--- a/DragonShout/Locales/enUS.lua
+++ b/DragonShout/Locales/enUS.lua
@@ -36,6 +36,9 @@ L["Open settings panel"] = true
 L["Show current settings"] = true
 L["Addon enabled"] = true
 L["Addon disabled"] = true
+L["Solo"] = true
+L["Group"] = true
+L["Addon not yet initialized."] = true
 L["Unknown command: "] = true
 L["Debug"] = true
 L["Debug Mode"] = true
@@ -90,6 +93,15 @@ L["Party"] = true
 L["Raid"] = true
 L["Say"] = true
 L["Yell"] = true
+L["Local"] = true
+L["Instance"] = true
+L["Officer"] = true
+L["Solo Channel"] = true
+L["Group Channel"] = true
+L["Raid/Instance Channel"] = true
+L["Channel used when not in any group (LOCAL prints only to your own chat frame)"] = true
+L["Channel used when in a party"] = true
+L["Channel used when in a raid or instance group"] = true
 
 -- DragonShout_Options/Tabs/CCOnYouTab.lua
 L["Enable CC-on-you announcements"] = true

--- a/DragonShout_Options/Core.lua
+++ b/DragonShout_Options/Core.lua
@@ -46,11 +46,13 @@ local L = ns.L
 -------------------------------------------------------------------------------
 
 ns.CHANNEL_VALUES = {
-    { value = "AUTO",  text = L["Auto"] },
-    { value = "PARTY", text = L["Party"] },
-    { value = "RAID",  text = L["Raid"] },
-    { value = "SAY",   text = L["Say"] },
-    { value = "YELL",  text = L["Yell"] },
+    { value = "LOCAL",         text = L["Local"] },
+    { value = "PARTY",         text = L["Party"] },
+    { value = "RAID",          text = L["Raid"] },
+    { value = "INSTANCE_CHAT", text = L["Instance"] },
+    { value = "SAY",           text = L["Say"] },
+    { value = "YELL",          text = L["Yell"] },
+    { value = "OFFICER",       text = L["Officer"] },
 }
 
 -------------------------------------------------------------------------------

--- a/DragonShout_Options/Tabs/CCAppliedTab.lua
+++ b/DragonShout_Options/Tabs/CCAppliedTab.lua
@@ -48,14 +48,32 @@ local function CreateContent(parent)
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local channelDropdown = W.CreateDropdown(content, {
-        label = L["Channel"],
-        tooltip = L["Chat channel to send announcements to"],
+    local soloDropdown = W.CreateDropdown(content, {
+        label = L["Solo Channel"],
+        tooltip = L["Channel used when not in any group (LOCAL prints only to your own chat frame)"],
         values = ns.CHANNEL_VALUES,
-        get = function() return db.profile.ccApplied.channel end,
-        set = function(value) db.profile.ccApplied.channel = value end,
+        get = function() return db.profile.ccApplied.channelSolo end,
+        set = function(value) db.profile.ccApplied.channelSolo = value end,
     })
-    innerY = LC.AnchorWidget(channelDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    innerY = LC.AnchorWidget(soloDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local groupDropdown = W.CreateDropdown(content, {
+        label = L["Group Channel"],
+        tooltip = L["Channel used when in a party"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.ccApplied.channelGroup end,
+        set = function(value) db.profile.ccApplied.channelGroup = value end,
+    })
+    innerY = LC.AnchorWidget(groupDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local raidDropdown = W.CreateDropdown(content, {
+        label = L["Raid/Instance Channel"],
+        tooltip = L["Channel used when in a raid or instance group"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.ccApplied.channelRaid end,
+        set = function(value) db.profile.ccApplied.channelRaid = value end,
+    })
+    innerY = LC.AnchorWidget(raidDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local templateInput = W.CreateTextInput(content, {
         label = L["Template"],

--- a/DragonShout_Options/Tabs/CCOnYouTab.lua
+++ b/DragonShout_Options/Tabs/CCOnYouTab.lua
@@ -50,14 +50,32 @@ local function CreateContent(parent)
     })
     innerY = LC.AnchorWidget(enableToggle, content1, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local channelDropdown = W.CreateDropdown(content1, {
-        label = L["Channel"],
-        tooltip = L["Chat channel to send announcements to"],
+    local soloDropdown = W.CreateDropdown(content1, {
+        label = L["Solo Channel"],
+        tooltip = L["Channel used when not in any group (LOCAL prints only to your own chat frame)"],
         values = ns.CHANNEL_VALUES,
-        get = function() return db.profile.ccOnYou.channel end,
-        set = function(value) db.profile.ccOnYou.channel = value end,
+        get = function() return db.profile.ccOnYou.channelSolo end,
+        set = function(value) db.profile.ccOnYou.channelSolo = value end,
     })
-    innerY = LC.AnchorWidget(channelDropdown, content1, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    innerY = LC.AnchorWidget(soloDropdown, content1, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local groupDropdown = W.CreateDropdown(content1, {
+        label = L["Group Channel"],
+        tooltip = L["Channel used when in a party"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.ccOnYou.channelGroup end,
+        set = function(value) db.profile.ccOnYou.channelGroup = value end,
+    })
+    innerY = LC.AnchorWidget(groupDropdown, content1, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local raidDropdown = W.CreateDropdown(content1, {
+        label = L["Raid/Instance Channel"],
+        tooltip = L["Channel used when in a raid or instance group"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.ccOnYou.channelRaid end,
+        set = function(value) db.profile.ccOnYou.channelRaid = value end,
+    })
+    innerY = LC.AnchorWidget(raidDropdown, content1, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local templateInput = W.CreateTextInput(content1, {
         label = L["Template"],

--- a/DragonShout_Options/Tabs/DispelsTab.lua
+++ b/DragonShout_Options/Tabs/DispelsTab.lua
@@ -48,14 +48,32 @@ local function CreateContent(parent)
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local channelDropdown = W.CreateDropdown(content, {
-        label = L["Channel"],
-        tooltip = L["Chat channel to send announcements to"],
+    local soloDropdown = W.CreateDropdown(content, {
+        label = L["Solo Channel"],
+        tooltip = L["Channel used when not in any group (LOCAL prints only to your own chat frame)"],
         values = ns.CHANNEL_VALUES,
-        get = function() return db.profile.dispels.channel end,
-        set = function(value) db.profile.dispels.channel = value end,
+        get = function() return db.profile.dispels.channelSolo end,
+        set = function(value) db.profile.dispels.channelSolo = value end,
     })
-    innerY = LC.AnchorWidget(channelDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    innerY = LC.AnchorWidget(soloDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local groupDropdown = W.CreateDropdown(content, {
+        label = L["Group Channel"],
+        tooltip = L["Channel used when in a party"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.dispels.channelGroup end,
+        set = function(value) db.profile.dispels.channelGroup = value end,
+    })
+    innerY = LC.AnchorWidget(groupDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local raidDropdown = W.CreateDropdown(content, {
+        label = L["Raid/Instance Channel"],
+        tooltip = L["Channel used when in a raid or instance group"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.dispels.channelRaid end,
+        set = function(value) db.profile.dispels.channelRaid = value end,
+    })
+    innerY = LC.AnchorWidget(raidDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local templateInput = W.CreateTextInput(content, {
         label = L["Template"],

--- a/DragonShout_Options/Tabs/InterruptsTab.lua
+++ b/DragonShout_Options/Tabs/InterruptsTab.lua
@@ -48,14 +48,32 @@ local function CreateContent(parent)
     })
     innerY = LC.AnchorWidget(enableToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
-    local channelDropdown = W.CreateDropdown(content, {
-        label = L["Channel"],
-        tooltip = L["Chat channel to send announcements to"],
+    local soloDropdown = W.CreateDropdown(content, {
+        label = L["Solo Channel"],
+        tooltip = L["Channel used when not in any group (LOCAL prints only to your own chat frame)"],
         values = ns.CHANNEL_VALUES,
-        get = function() return db.profile.interrupts.channel end,
-        set = function(value) db.profile.interrupts.channel = value end,
+        get = function() return db.profile.interrupts.channelSolo end,
+        set = function(value) db.profile.interrupts.channelSolo = value end,
     })
-    innerY = LC.AnchorWidget(channelDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+    innerY = LC.AnchorWidget(soloDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local groupDropdown = W.CreateDropdown(content, {
+        label = L["Group Channel"],
+        tooltip = L["Channel used when in a party"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.interrupts.channelGroup end,
+        set = function(value) db.profile.interrupts.channelGroup = value end,
+    })
+    innerY = LC.AnchorWidget(groupDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local raidDropdown = W.CreateDropdown(content, {
+        label = L["Raid/Instance Channel"],
+        tooltip = L["Channel used when in a raid or instance group"],
+        values = ns.CHANNEL_VALUES,
+        get = function() return db.profile.interrupts.channelRaid end,
+        set = function(value) db.profile.interrupts.channelRaid = value end,
+    })
+    innerY = LC.AnchorWidget(raidDropdown, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
 
     local templateInput = W.CreateTextInput(content, {
         label = L["Template"],


### PR DESCRIPTION
## Description

Replace the single `channel = \"AUTO\"` setting per announcement category with separate `channelSolo`, `channelGroup`, and `channelRaid` fields. The announcer now resolves the correct channel from group context, and the options UI exposes the three dropdowns for each category.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issues

Closes #5

## Testing

- [ ] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [x] WoW version(s) tested on: All versions

## Screenshots

N/A

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game
- [ ] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel routing is now context-aware with separate settings for solo, group, and raid scenarios across all notification categories (Interrupts, CC on You, CC Applied, Dispels).

* **Bug Fixes**
  * Improved fallback behavior for missing channel configuration, now defaulting to appropriate channels per context.

* **UI Updates**
  * Replaced single channel dropdown with three context-specific options in settings interface.
  * Added new channel options: Local, Instance, and Officer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->