### PR TITLE
fix: correct DragonWidgets external path in .pkgmeta

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -10,7 +10,7 @@ externals:
   DragonShout/Libs/Ace3: https://repos.wowace.com/wow/ace3/trunk
   DragonShout/Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
   DragonShout/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
-  DragonShout/DragonShout_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
+  DragonShout_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
 
 ignore:
   - ".git*"


### PR DESCRIPTION
\ had an incorrect prefix that prevented the BigWigsMods packager from placing it in the right location.

**Before:**
\
\
\
\
DragonShout/DragonShout_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
\
\
\
\
**After:**
\
\
\
\
DragonShout_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
\
\
\
\
The \\move-folders\\ directive maps \\DragonShout/DragonShout_Options\\ -> \\DragonShout_Options\\. The external path key must match the **pre-move** structure relative to the repo root. Using the \\DragonShout/\\ prefix caused the packager to place DragonWidgets inside a stray nested folder instead of \\DragonShout_Options/Libs/DragonWidgets/\\, making \\DragonWidgetsNS\\ undefined at runtime and breaking the options UI.

This is the same bug as DragonLoot#136.

## Type of Change
- [x] Bug fix

## Testing
- Packaging: trigger \\packager.yml\\ and verify DragonWidgets lands in \\DragonShout_Options/Libs/DragonWidgets/DragonWidgets/\\ in the built zip.

## Checklist
- [x] \\.pkgmeta\\ external path corrected
- [x] No other files changed