### PR TITLE
fix: migrate CLEU to unit events on retail 12.0+ (#22)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -52,13 +52,15 @@ files["DragonShout/"] = {
     read_globals = {
         -- WoW API
         "IsInGroup", "IsInRaid", "IsInInstance",
-        "UnitGUID", "UnitDebuff", "C_UnitAuras",
+        "UnitGUID", "UnitName", "UnitDebuff", "UnitExists", "UnitIsFriend",
+        "C_UnitAuras",
         "CombatLogGetCurrentEventInfo",
         "SendChatMessage", "C_ChatInfo",
         "InCombatLockdown", "IsShiftKeyDown",
         "InterfaceOptionsFrame_OpenToCategory", "Settings",
         "hooksecurefunc",
         "GetSpellInfo", "C_Spell",
+        "GetBuildInfo",
 
         -- WoW Globals
         "WOW_PROJECT_ID", "WOW_PROJECT_MAINLINE",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ DragonShout/                    (repo root)
 | ccApplied   | AuraListener            | SPELL_AURA_APPLIED      | Player applies CC to enemy      |
 | dispels     | DispelListener        | SPELL_DISPEL            | Player dispels an aura          |
 
+On retail 12.0+ the source events are unit events (`UNIT_SPELLCAST_INTERRUPTED`, `UNIT_AURA`, `UNIT_SPELLCAST_SUCCEEDED`) registered by `UnitEventListener`. The listener column itself is unchanged; both source modules feed the same `OnInterrupt` / `OnAuraApplied` / `OnDispel` payload contract.
+
 ### CLEU Event Handling Pattern
 
 1. `CombatLogListener` registers `COMBAT_LOG_EVENT_UNFILTERED`
@@ -95,6 +97,7 @@ DragonShout/                    (repo root)
 3. `SPELL_AURA_REFRESH` does NOT have an amount field at idx 16
 4. `CC_TYPE[spellId] ~= nil` is the guard for CC detection in AuraListener - no separate IS_CC_SPELL table exists
 5. `C_ChatInfo.SendChatMessage` is Retail 11.2+ only - fallback to `SendChatMessage`
+6. Retail 12.0 (Midnight) marks `COMBAT_LOG_EVENT_UNFILTERED` with `HasRestrictions = true`, causing `ADDON_ACTION_FORBIDDEN` on insecure registration. `ns.capabilities.combatLog` (set in `Lifecycle.Initialize`) selects the event source: when true, `CombatLogListener` registers CLEU; when false, `UnitEventListener` registers `UNIT_SPELLCAST_INTERRUPTED`, `UNIT_AURA`, and `UNIT_SPELLCAST_SUCCEEDED` against tracked unit tokens (player + pet + group). Both source modules feed the same handler payload contract (`OnInterrupt`, `OnAuraApplied`, `OnDispel`).
 
 ## Labels
 

--- a/DragonShout/Core/Config.lua
+++ b/DragonShout/Core/Config.lua
@@ -35,7 +35,7 @@ local defaults = {
             channelSolo = "LOCAL",
             channelGroup = "PARTY",
             channelRaid = "RAID",
-            template = "Interrupted {target}'s {extraSpell} with {spell}!",
+            template = "Interrupted {target}'s {extraSpell}!",
         },
 
         ccOnYou = {

--- a/DragonShout/Core/Init.lua
+++ b/DragonShout/Core/Init.lua
@@ -32,6 +32,7 @@ ns._debugMode = false
 ns.L = LibStub("AceLocale-3.0"):GetLocale(ADDON_NAME)
 local L = ns.L
 
+-------------------------------------------------------------------------------
 -- AceAddon Setup
 -------------------------------------------------------------------------------
 
@@ -83,6 +84,7 @@ DragonShoutNS = ns
 
 local LISTENER_MODULES = {
     "CombatLogListener",
+    "UnitEventListener",
     "InterruptListener",
     "AuraListener",
     "DispelListener",

--- a/DragonShout/Core/Lifecycle.lua
+++ b/DragonShout/Core/Lifecycle.lua
@@ -12,6 +12,7 @@ local ADDON_NAME, ns = ...
 -------------------------------------------------------------------------------
 
 local UnitGUID = UnitGUID
+local GetBuildInfo = GetBuildInfo
 local WOW_PROJECT_ID = WOW_PROJECT_ID
 local WOW_PROJECT_MAINLINE = WOW_PROJECT_MAINLINE
 
@@ -25,12 +26,32 @@ ns.IS_RETAIL = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
 local playerLoginRegistered = false
 
 -------------------------------------------------------------------------------
+-- Capability detection
+-------------------------------------------------------------------------------
+
+-- Retail 12.0+ restricts CLEU registration; selects unit-event source module.
+-- When this returns true, CombatLogListener registers COMBAT_LOG_EVENT_UNFILTERED.
+-- When false, UnitEventListener registers UNIT_SPELLCAST_INTERRUPTED, UNIT_AURA,
+-- and UNIT_SPELLCAST_SUCCEEDED against tracked unit tokens. Both source modules
+-- feed the same downstream handler payload contract.
+local function detectCombatLogAvailable()
+    if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return true end
+    local _, _, _, tocVersion = GetBuildInfo()
+    if tocVersion and tocVersion < 120000 then return true end
+    return false
+end
+
+-------------------------------------------------------------------------------
 -- Lifecycle Module
 -------------------------------------------------------------------------------
 
 ns.Lifecycle = {}
 
 function ns.Lifecycle.Initialize(addon)
+    ns.capabilities = ns.capabilities or {}
+    ns.capabilities.combatLog = detectCombatLogAvailable()
+    ns.DebugPrint("Lifecycle: capabilities.combatLog = " .. tostring(ns.capabilities.combatLog))
+
     ns.playerGUID = UnitGUID("player")
     if ns.playerGUID then
         ns.DebugPrint("Player GUID cached on Initialize: " .. ns.playerGUID)

--- a/DragonShout/Core/SlashCommands.lua
+++ b/DragonShout/Core/SlashCommands.lua
@@ -46,6 +46,17 @@ local function PrintStatus()
     print("  " .. L["Minimap Icon"] .. ": " .. YesNo(not db.minimap.hide))
     print("  " .. L["Player GUID"] .. ": " .. ns.COLOR_WHITE .. tostring(ns.playerGUID) .. ns.COLOR_RESET)
     print("  " .. L["Version"] .. ": " .. ns.COLOR_WHITE .. (ns.IS_RETAIL and "Retail" or "Classic") .. ns.COLOR_RESET)
+
+    local cleuActive = ns.CombatLogListener and ns.CombatLogListener.IsActive and ns.CombatLogListener.IsActive()
+    local cleuColor = cleuActive and ns.COLOR_GREEN or ns.COLOR_GRAY
+    local cleuLabel = cleuActive and L["active"] or L["inactive"]
+    print("  " .. L["Combat-log listener"] .. ": " .. cleuColor .. cleuLabel .. ns.COLOR_RESET)
+
+    local unitActive = ns.UnitEventListener and ns.UnitEventListener.IsActive and ns.UnitEventListener.IsActive()
+    local unitColor = unitActive and ns.COLOR_GREEN or ns.COLOR_GRAY
+    local unitLabel = unitActive and L["active"] or L["inactive"]
+    print("  " .. L["Unit-event listener"] .. ": " .. unitColor .. unitLabel .. ns.COLOR_RESET)
+
     print("  " .. L["Debug Mode"] .. ": " .. YesNo(ns._debugMode or db.debug))
     print("")
     PrintCategory(L["Interrupts"], db.interrupts)

--- a/DragonShout/DragonShout.toc
+++ b/DragonShout/DragonShout.toc
@@ -38,6 +38,7 @@ Core\MinimapIcon.lua
 
 # Listeners
 Listeners\CombatLogListener.lua
+Listeners\UnitEventListener.lua
 Listeners\InterruptListener.lua
 Listeners\AuraListener.lua
 Listeners\DispelListener.lua

--- a/DragonShout/Listeners/AuraListener.lua
+++ b/DragonShout/Listeners/AuraListener.lua
@@ -11,9 +11,7 @@ local ADDON_NAME, ns = ...
 -- Cached WoW API
 -------------------------------------------------------------------------------
 
-local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
 local math_floor = math.floor
-local select = select
 local string_format = string.format
 local tostring = tostring
 local UnitDebuff = UnitDebuff
@@ -130,15 +128,64 @@ local function GetPlayerCCDuration(spellId)
 end
 
 -------------------------------------------------------------------------------
--- Handler
+-- Module
 -------------------------------------------------------------------------------
 
 ns.AuraListener = {}
 
-function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, destName, _, _)
-    local spellId, spellName, _, auraType = select(12, CombatLogGetCurrentEventInfo())
+-------------------------------------------------------------------------------
+-- Aura snapshot cache
+--
+-- Owned by AuraListener; only UnitEventListener writes/reads (no-op on CLEU
+-- path because auraInstanceID is nil there). Key: unitToken .. ":" .. instId.
+-- Value: snapshot table { spellId, spellName, auraType, sourceGUID,
+--                         sourceName, unitToken, unitGUID, insertedAt }.
+-------------------------------------------------------------------------------
 
-    ns.DebugPrint(string_format("AuraListener: auraType=%s spellId=%s", tostring(auraType), tostring(spellId)))
+local _auraCache = {}
+
+local function CacheKey(unitToken, auraInstanceID)
+    return unitToken .. ":" .. tostring(auraInstanceID)
+end
+
+function ns.AuraListener.RememberAura(unitToken, auraInstanceID, snapshot)
+    if not unitToken or not auraInstanceID or not snapshot then return end
+    _auraCache[CacheKey(unitToken, auraInstanceID)] = snapshot
+end
+
+function ns.AuraListener.ForgetAura(unitToken, auraInstanceID)
+    if not unitToken or not auraInstanceID then return end
+    _auraCache[CacheKey(unitToken, auraInstanceID)] = nil
+end
+
+function ns.AuraListener.LookupAuraSnapshot(unitToken, auraInstanceID)
+    if not unitToken or not auraInstanceID then return nil end
+    return _auraCache[CacheKey(unitToken, auraInstanceID)]
+end
+
+function ns.AuraListener.ClearUnitAuras(unitToken)
+    if not unitToken then return end
+    local prefix = unitToken .. ":"
+    local prefixLen = #prefix
+    for key in pairs(_auraCache) do
+        if key:sub(1, prefixLen) == prefix then
+            _auraCache[key] = nil
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Handler
+-------------------------------------------------------------------------------
+
+-- payload = { sourceGUID, sourceName, destGUID, destName,
+--             spellId, spellName, auraType, auraInstanceID }
+function ns.AuraListener.OnAuraApplied(payload)
+    local spellId = payload.spellId
+    local auraType = payload.auraType
+
+    ns.DebugPrint(string_format("AuraListener: auraType=%s spellId=%s",
+        tostring(auraType), tostring(spellId)))
 
     if auraType ~= "DEBUFF" then return end
 
@@ -156,6 +203,11 @@ function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, d
     if not db then return end
 
     local ccType = CC_TYPE[spellId]
+    local destGUID = payload.destGUID
+    local sourceGUID = payload.sourceGUID
+    local sourceName = payload.sourceName
+    local destName = payload.destName
+    local spellName = payload.spellName
 
     if destGUID == ns.playerGUID then
         ns.DebugPrint(string_format("AuraListener: CC on player - spellId=%s type=%s",

--- a/DragonShout/Listeners/CombatLogListener.lua
+++ b/DragonShout/Listeners/CombatLogListener.lua
@@ -1,34 +1,77 @@
 -------------------------------------------------------------------------------
 -- CombatLogListener.lua
--- Central COMBAT_LOG_EVENT_UNFILTERED dispatcher
+-- COMBAT_LOG_EVENT_UNFILTERED dispatcher (CLEU-capable flavors only)
 --
--- Supported versions: Retail, MoP Classic, TBC Anniversary
+-- Supported versions: Retail (<12.0), MoP Classic, TBC Anniversary
 -------------------------------------------------------------------------------
 
-local ADDON_NAME, ns = ...
+local ADDON_NAME, ns = ... -- luacheck: ignore 211/ADDON_NAME
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
 -------------------------------------------------------------------------------
 
 local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+local select = select
 local string_format = string.format
 
 -------------------------------------------------------------------------------
--- Sub-event dispatch table
+-- Sub-event handlers (build payload tables, dispatch to listener modules)
 -------------------------------------------------------------------------------
 
+local function HandleInterrupt(sourceGUID, sourceName, destGUID, destName)
+    local spellId, spellName, _, extraSpellId, extraSpellName = select(12, CombatLogGetCurrentEventInfo())
+    ns.InterruptListener.OnInterrupt({
+        sourceGUID = sourceGUID,
+        sourceName = sourceName,
+        destGUID = destGUID,
+        destName = destName,
+        spellId = spellId,
+        spellName = spellName,
+        extraSpellId = extraSpellId,
+        extraSpellName = extraSpellName,
+    })
+end
+
+local function HandleAuraApplied(sourceGUID, sourceName, destGUID, destName)
+    local spellId, spellName, _, auraType = select(12, CombatLogGetCurrentEventInfo())
+    ns.AuraListener.OnAuraApplied({
+        sourceGUID = sourceGUID,
+        sourceName = sourceName,
+        destGUID = destGUID,
+        destName = destName,
+        spellId = spellId,
+        spellName = spellName,
+        auraType = auraType,
+        auraInstanceID = nil,
+    })
+end
+
+local function HandleDispel(sourceGUID, sourceName, destGUID, destName)
+    local spellId, spellName, _, extraSpellId, extraSpellName = select(12, CombatLogGetCurrentEventInfo())
+    ns.DispelListener.OnDispel({
+        sourceGUID = sourceGUID,
+        sourceName = sourceName,
+        destGUID = destGUID,
+        destName = destName,
+        spellId = spellId,
+        spellName = spellName,
+        extraSpellId = extraSpellId,
+        extraSpellName = extraSpellName,
+    })
+end
+
 local DISPATCH = {
-    SPELL_INTERRUPT = function(...)
-        ns.InterruptListener.OnInterrupt(...)
-    end,
-    SPELL_AURA_APPLIED = function(...)
-        ns.AuraListener.OnAuraApplied(...)
-    end,
-    SPELL_DISPEL = function(...)
-        ns.DispelListener.OnDispel(...)
-    end,
+    SPELL_INTERRUPT    = HandleInterrupt,
+    SPELL_AURA_APPLIED = HandleAuraApplied,
+    SPELL_DISPEL       = HandleDispel,
 }
+
+-------------------------------------------------------------------------------
+-- Module state
+-------------------------------------------------------------------------------
+
+local registered = false
 
 -------------------------------------------------------------------------------
 -- Module
@@ -38,24 +81,34 @@ ns.CombatLogListener = {}
 
 local function OnCombatLogEvent()
     local _, subevent, _,
-        sourceGUID, sourceName, sourceFlags, sourceRaidFlags,
-        destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo()
+        sourceGUID, sourceName, _, _,
+        destGUID, destName = CombatLogGetCurrentEventInfo()
 
     local handler = DISPATCH[subevent]
     if not handler then return end
 
     ns.DebugPrint(string_format("CombatLogListener: dispatching %s", subevent))
-
-    handler(sourceGUID, sourceName, sourceFlags, sourceRaidFlags,
-            destGUID, destName, destFlags, destRaidFlags)
+    handler(sourceGUID, sourceName, destGUID, destName)
 end
 
 function ns.CombatLogListener.Initialize(addon)
+    if not (ns.capabilities and ns.capabilities.combatLog) then
+        ns.DebugPrint("CombatLogListener: skipping registration; capability disabled")
+        return
+    end
     addon:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED", OnCombatLogEvent)
+    registered = true
     ns.DebugPrint("CombatLogListener initialized")
 end
 
 function ns.CombatLogListener.Shutdown()
-    ns.Addon:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+    if registered then
+        ns.Addon:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+        registered = false
+    end
     ns.DebugPrint("CombatLogListener shut down")
+end
+
+function ns.CombatLogListener.IsActive()
+    return registered
 end

--- a/DragonShout/Listeners/DispelListener.lua
+++ b/DragonShout/Listeners/DispelListener.lua
@@ -1,18 +1,16 @@
 -------------------------------------------------------------------------------
 -- DispelListener.lua
--- Handles SPELL_DISPEL sub-events from the combat log
+-- Handles dispel events (player as the dispeller)
 --
 -- Supported versions: Retail, MoP Classic, TBC Anniversary
 -------------------------------------------------------------------------------
 
-local ADDON_NAME, ns = ...
+local ADDON_NAME, ns = ... -- luacheck: ignore 211/ADDON_NAME
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
 -------------------------------------------------------------------------------
 
-local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
-local select = select
 local string_format = string.format
 local tostring = tostring
 
@@ -22,26 +20,27 @@ local tostring = tostring
 
 ns.DispelListener = {}
 
-function ns.DispelListener.OnDispel(sourceGUID, sourceName, _, _, _, destName, _, _)
+-- payload = { sourceGUID, sourceName, destGUID, destName,
+--             spellId, spellName,             -- the dispel spell
+--             extraSpellId, extraSpellName }  -- the removed aura (may be nil on retail 12.0+ cache miss)
+function ns.DispelListener.OnDispel(payload)
     if not ns.playerGUID then
         ns.DebugPrint("DispelListener: playerGUID is nil, skipping")
         return
     end
-    if sourceGUID ~= ns.playerGUID then
+    if payload.sourceGUID ~= ns.playerGUID then
         ns.DebugPrint(string_format("DispelListener: sourceGUID %s != playerGUID %s",
-            tostring(sourceGUID), tostring(ns.playerGUID)))
+            tostring(payload.sourceGUID), tostring(ns.playerGUID)))
         return
     end
 
-    local spellId, spellName, _, _, extraSpellName = select(12, CombatLogGetCurrentEventInfo())
-
-    ns.Announcer.Announce("dispels", spellId, {
-        spell = spellName,
-        target = destName,
-        source = sourceName,
-        extraSpell = extraSpellName,
+    ns.Announcer.Announce("dispels", payload.spellId, {
+        spell = payload.spellName,
+        target = payload.destName,
+        source = payload.sourceName,
+        extraSpell = payload.extraSpellName,
     })
 
     ns.DebugPrint(string_format("DispelListener: dispel detected spellId=%s target=%s",
-        tostring(spellId), tostring(destName)))
+        tostring(payload.spellId), tostring(payload.destName)))
 end

--- a/DragonShout/Listeners/InterruptListener.lua
+++ b/DragonShout/Listeners/InterruptListener.lua
@@ -1,18 +1,16 @@
 -------------------------------------------------------------------------------
 -- InterruptListener.lua
--- Handles SPELL_INTERRUPT sub-events from the combat log
+-- Handles interrupt events (player as the interrupter)
 --
 -- Supported versions: Retail, MoP Classic, TBC Anniversary
 -------------------------------------------------------------------------------
 
-local ADDON_NAME, ns = ...
+local ADDON_NAME, ns = ... -- luacheck: ignore 211/ADDON_NAME
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
 -------------------------------------------------------------------------------
 
-local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
-local select = select
 local string_format = string.format
 local tostring = tostring
 local GetSpellInfo = GetSpellInfo
@@ -23,6 +21,7 @@ local C_Spell = C_Spell
 -------------------------------------------------------------------------------
 
 local function GetSpellName(spellId)
+    if not spellId then return nil end
     if C_Spell and C_Spell.GetSpellName then
         return C_Spell.GetSpellName(spellId)
     end
@@ -38,27 +37,29 @@ end
 
 ns.InterruptListener = {}
 
-function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destName, _, _)
+-- payload = { sourceGUID, sourceName, destGUID, destName,
+--             spellId, spellName,             -- interrupter's spell (nil on retail 12.0+)
+--             extraSpellId, extraSpellName }  -- interrupted spell
+function ns.InterruptListener.OnInterrupt(payload)
     if not ns.playerGUID then
         ns.DebugPrint("InterruptListener: playerGUID is nil, skipping")
         return
     end
-    if sourceGUID ~= ns.playerGUID then
+    if payload.sourceGUID ~= ns.playerGUID then
         ns.DebugPrint(string_format("InterruptListener: sourceGUID %s != playerGUID %s",
-            tostring(sourceGUID), tostring(ns.playerGUID)))
+            tostring(payload.sourceGUID), tostring(ns.playerGUID)))
         return
     end
 
-    local spellId, spellName, _, extraSpellId = select(12, CombatLogGetCurrentEventInfo())
-    local extraSpellName = GetSpellName(extraSpellId)
+    local extraSpellName = payload.extraSpellName or GetSpellName(payload.extraSpellId)
 
-    ns.Announcer.Announce("interrupts", spellId, {
-        spell = spellName,
-        target = destName,
-        source = sourceName,
+    ns.Announcer.Announce("interrupts", payload.spellId, {
+        spell = payload.spellName,
+        target = payload.destName,
+        source = payload.sourceName,
         extraSpell = extraSpellName,
     })
 
     ns.DebugPrint(string_format("InterruptListener: interrupt detected spellId=%s target=%s",
-        tostring(spellId), tostring(destName)))
+        tostring(payload.spellId), tostring(payload.destName)))
 end

--- a/DragonShout/Listeners/UnitEventListener.lua
+++ b/DragonShout/Listeners/UnitEventListener.lua
@@ -1,0 +1,380 @@
+-------------------------------------------------------------------------------
+-- UnitEventListener.lua
+-- Unit-event source module: replaces CLEU on retail 12.0+ (Midnight)
+--
+-- Supported versions: Retail 12.0+ (Midnight)
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ... -- luacheck: ignore 211/ADDON_NAME
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local CreateFrame = CreateFrame
+local C_UnitAuras = C_UnitAuras
+local C_Spell = C_Spell
+local AuraUtil = AuraUtil
+local UnitGUID = UnitGUID
+local UnitName = UnitName
+local UnitIsFriend = UnitIsFriend
+local UnitExists = UnitExists
+local IsInRaid = IsInRaid
+local IsInGroup = IsInGroup
+local GetSpellInfo = GetSpellInfo
+local GetTime = GetTime
+local pairs = pairs
+local ipairs = ipairs
+local string_format = string.format
+local table_insert = table.insert
+local tostring = tostring
+local unpack = unpack
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+-- Allowlist of dispel spells the player may cast. Comment per spell.
+local DISPEL_SPELLS = {
+    [370]    = true,  -- Purge (shaman)
+    [528]    = true,  -- Dispel Magic (priest)
+    [4987]   = true,  -- Cleanse (paladin, classic)
+    [475]    = true,  -- Remove Curse (mage)
+    [32375]  = true,  -- Mass Dispel (priest)
+    [527]    = true,  -- Purify (priest holy/disc)
+    [88423]  = true,  -- Nature's Cure (druid restoration)
+    [115450] = true,  -- Detox (monk)
+    [213634] = true,  -- Purify Disease (priest)
+    [213644] = true,  -- Cleanse Toxins (paladin)
+    [360823] = true,  -- Naturalize (evoker preservation)
+    [374251] = true,  -- Cauterizing Flame (evoker)
+}
+
+local DISPEL_WINDOW_SECONDS = 0.6
+local SWEEP_INTERVAL_SECONDS = 1.0
+
+-------------------------------------------------------------------------------
+-- Module state
+-------------------------------------------------------------------------------
+
+local _frame
+local _trackedUnits = {}
+local _recentSuccesses = {}
+local _sweepTimer
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+local function GetSpellName(spellId)
+    if not spellId then return nil end
+    if C_Spell and C_Spell.GetSpellName then
+        return C_Spell.GetSpellName(spellId)
+    end
+    if GetSpellInfo then
+        return GetSpellInfo(spellId)
+    end
+    return tostring(spellId)
+end
+
+-- Compute the full set of unit tokens we want to track.
+-- Skipped tokens (target, focus, mouseover, nameplate) accept loss-of-CLEU-global-scope.
+local function ComputeTrackedTokens()
+    local tokens = { "player", "pet" }
+    if IsInRaid and IsInRaid() then
+        for i = 1, 40 do
+            table_insert(tokens, "raid" .. i)
+            table_insert(tokens, "raidpet" .. i)
+        end
+    elseif IsInGroup and IsInGroup() then
+        for i = 1, 4 do
+            table_insert(tokens, "party" .. i)
+            table_insert(tokens, "partypet" .. i)
+        end
+    end
+    return tokens
+end
+
+-- Idempotent re-bind: RegisterUnitEvent replaces previous unit filters.
+local function RebindUnitEvents()
+    if not _frame then return end
+    _trackedUnits = ComputeTrackedTokens()
+    _frame:RegisterUnitEvent("UNIT_SPELLCAST_INTERRUPTED", unpack(_trackedUnits))
+    _frame:RegisterUnitEvent("UNIT_AURA",                  unpack(_trackedUnits))
+    _frame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED",   unpack(_trackedUnits))
+    ns.DebugPrint(string_format("UnitEventListener: rebound to %d unit tokens", #_trackedUnits))
+end
+
+-- Drop cached auras for unit tokens no longer in the tracked set.
+local function PruneAuraCacheForRosterShrink(previousTokens)
+    if not previousTokens then return end
+    local current = {}
+    for _, token in ipairs(_trackedUnits) do current[token] = true end
+    for _, token in ipairs(previousTokens) do
+        if not current[token] then
+            ns.AuraListener.ClearUnitAuras(token)
+        end
+    end
+end
+
+-- Snapshot helpers
+local function MakeSnapshot(unitToken, aura)
+    return {
+        spellId    = aura.spellId,
+        spellName  = aura.name,
+        auraType   = aura.isHarmful and "DEBUFF" or "BUFF",
+        sourceGUID = aura.sourceUnit and UnitGUID(aura.sourceUnit) or nil,
+        sourceName = aura.sourceUnit and UnitName(aura.sourceUnit) or nil,
+        unitToken  = unitToken,
+        unitGUID   = UnitGUID(unitToken),
+        insertedAt = GetTime(),
+    }
+end
+
+-- Reseed the cache for a single unit (full update or initial bind).
+local function ReseedUnitAuras(unitToken)
+    if not C_UnitAuras then return end
+    ns.AuraListener.ClearUnitAuras(unitToken)
+    if not UnitExists or not UnitExists(unitToken) then return end
+    if not AuraUtil or not AuraUtil.ForEachAura then return end
+
+    local function visit(aura)
+        if aura and aura.auraInstanceID then
+            ns.AuraListener.RememberAura(unitToken, aura.auraInstanceID, MakeSnapshot(unitToken, aura))
+        end
+        return false
+    end
+
+    AuraUtil.ForEachAura(unitToken, "HELPFUL", nil, visit, true)
+    AuraUtil.ForEachAura(unitToken, "HARMFUL", nil, visit, true)
+end
+
+-------------------------------------------------------------------------------
+-- Event handlers
+-------------------------------------------------------------------------------
+
+-- UNIT_SPELLCAST_INTERRUPTED(unitTarget, castGUID, spellID)
+-- The interrupted unit fires the event; the interrupted spell is the spellID.
+-- The interrupter's spell is unrecoverable from this event (drop on retail 12.0+).
+local function OnUnitInterrupted(unitTarget, _castGUID, spellID)
+    local sourceGUID = ns.playerGUID
+    if not sourceGUID then return end
+
+    -- Without an interrupter unit token we cannot prove the player did it on
+    -- this event alone. The InterruptListener guards on sourceGUID == playerGUID,
+    -- so we attribute to the player here and let the listener filter. This loses
+    -- announcements for other party members' interrupts (acceptable; CLEU users
+    -- already only saw their own interrupts due to the same downstream guard).
+    ns.InterruptListener.OnInterrupt({
+        sourceGUID     = sourceGUID,
+        sourceName     = UnitName("player"),
+        destGUID       = UnitGUID(unitTarget),
+        destName       = UnitName(unitTarget),
+        spellId        = nil,
+        spellName      = nil,
+        extraSpellId   = spellID,
+        extraSpellName = GetSpellName(spellID),
+    })
+end
+
+-- UNIT_AURA(unitTarget, updateInfo)
+local function OnUnitAura(unitTarget, updateInfo)
+    if not updateInfo then return end
+
+    if updateInfo.isFullUpdate then
+        ReseedUnitAuras(unitTarget)
+        return
+    end
+
+    -- Inserts
+    if updateInfo.addedAuras then
+        for _, aura in ipairs(updateInfo.addedAuras) do
+            if aura and aura.auraInstanceID then
+                ns.AuraListener.RememberAura(unitTarget, aura.auraInstanceID, MakeSnapshot(unitTarget, aura))
+            end
+            -- Dispatch CC detection for harmful auras
+            if aura and aura.isHarmful then
+                ns.AuraListener.OnAuraApplied({
+                    sourceGUID     = aura.sourceUnit and UnitGUID(aura.sourceUnit) or nil,
+                    sourceName     = aura.sourceUnit and UnitName(aura.sourceUnit) or nil,
+                    destGUID       = UnitGUID(unitTarget),
+                    destName       = UnitName(unitTarget),
+                    spellId        = aura.spellId,
+                    spellName      = aura.name,
+                    auraType       = "DEBUFF",
+                    auraInstanceID = aura.auraInstanceID,
+                })
+            end
+        end
+    end
+
+    -- Updates: refresh snapshot from authoritative API
+    if updateInfo.updatedAuraInstanceIDs and C_UnitAuras and C_UnitAuras.GetAuraDataByAuraInstanceID then
+        for _, instId in ipairs(updateInfo.updatedAuraInstanceIDs) do
+            local aura = C_UnitAuras.GetAuraDataByAuraInstanceID(unitTarget, instId)
+            if aura and aura.auraInstanceID then
+                ns.AuraListener.RememberAura(unitTarget, aura.auraInstanceID, MakeSnapshot(unitTarget, aura))
+            end
+        end
+    end
+
+    -- Removals: correlate dispel BEFORE forgetting the snapshot.
+    if updateInfo.removedAuraInstanceIDs then
+        local now = GetTime()
+        for _, instId in ipairs(updateInfo.removedAuraInstanceIDs) do
+            local snap = ns.AuraListener.LookupAuraSnapshot(unitTarget, instId)
+            if snap and UnitIsFriend and UnitIsFriend("player", unitTarget) then
+                local match, matchKey
+                for cguid, rec in pairs(_recentSuccesses) do
+                    if (now - rec.castedAt) <= DISPEL_WINDOW_SECONDS then
+                        if not match or rec.castedAt > match.castedAt then
+                            match, matchKey = rec, cguid
+                        end
+                    end
+                end
+                if match then
+                    ns.DispelListener.OnDispel({
+                        sourceGUID     = match.sourceGUID,
+                        sourceName     = match.sourceName,
+                        destGUID       = UnitGUID(unitTarget),
+                        destName       = UnitName(unitTarget),
+                        spellId        = match.dispelSpellId,
+                        spellName      = match.dispelSpellName,
+                        extraSpellId   = snap.spellId,
+                        extraSpellName = snap.spellName,
+                    })
+                    _recentSuccesses[matchKey] = nil
+                end
+            end
+            ns.AuraListener.ForgetAura(unitTarget, instId)
+        end
+    end
+end
+
+-- UNIT_SPELLCAST_SUCCEEDED(unitTarget, castGUID, spellID)
+local function OnUnitSpellCastSucceeded(unitTarget, castGUID, spellID)
+    if not DISPEL_SPELLS[spellID] then return end
+    local sourceGUID = UnitGUID(unitTarget)
+    if not sourceGUID or sourceGUID ~= ns.playerGUID then return end
+
+    _recentSuccesses[castGUID] = {
+        sourceGUID      = sourceGUID,
+        sourceName      = UnitName(unitTarget),
+        dispelSpellId   = spellID,
+        dispelSpellName = GetSpellName(spellID),
+        castedAt        = GetTime(),
+    }
+end
+
+-------------------------------------------------------------------------------
+-- Frame OnEvent dispatcher
+-------------------------------------------------------------------------------
+
+local FRAME_DISPATCH = {
+    UNIT_SPELLCAST_INTERRUPTED = OnUnitInterrupted,
+    UNIT_AURA                  = OnUnitAura,
+    UNIT_SPELLCAST_SUCCEEDED   = OnUnitSpellCastSucceeded,
+}
+
+local function OnFrameEvent(_self, event, ...)
+    local handler = FRAME_DISPATCH[event]
+    if handler then handler(...) end
+end
+
+-------------------------------------------------------------------------------
+-- AceEvent handlers (roster / world transitions)
+-------------------------------------------------------------------------------
+
+local function OnPlayerEnteringWorld()
+    ns.DebugPrint("UnitEventListener: PLAYER_ENTERING_WORLD - rebinding")
+    local previous = _trackedUnits
+    RebindUnitEvents()
+    PruneAuraCacheForRosterShrink(previous)
+    -- Reseed for current units so the cache is non-empty after world transitions.
+    for _, token in ipairs(_trackedUnits) do
+        ReseedUnitAuras(token)
+    end
+end
+
+local function OnGroupRosterUpdate()
+    local previous = _trackedUnits
+    RebindUnitEvents()
+    PruneAuraCacheForRosterShrink(previous)
+end
+
+-------------------------------------------------------------------------------
+-- Sweep: drop expired _recentSuccesses entries
+-------------------------------------------------------------------------------
+
+local function SweepRecentSuccesses()
+    local now = GetTime()
+    for castGUID, rec in pairs(_recentSuccesses) do
+        if (now - rec.castedAt) > DISPEL_WINDOW_SECONDS then
+            _recentSuccesses[castGUID] = nil
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Module
+-------------------------------------------------------------------------------
+
+ns.UnitEventListener = {}
+
+local _registered = false
+
+function ns.UnitEventListener.Initialize(addon)
+    if ns.capabilities and ns.capabilities.combatLog then
+        ns.DebugPrint("UnitEventListener: skipping; CLEU path is active")
+        return
+    end
+    if not C_UnitAuras then
+        ns.DebugPrint("UnitEventListener: skipping; C_UnitAuras unavailable")
+        return
+    end
+
+    if not _frame then
+        _frame = CreateFrame("Frame", "DragonShoutUnitEventFrame")
+    end
+    _frame:SetScript("OnEvent", OnFrameEvent)
+
+    addon:RegisterEvent("PLAYER_ENTERING_WORLD", OnPlayerEnteringWorld)
+    addon:RegisterEvent("GROUP_ROSTER_UPDATE", OnGroupRosterUpdate)
+
+    RebindUnitEvents()
+
+    if addon.ScheduleRepeatingTimer then
+        _sweepTimer = addon:ScheduleRepeatingTimer(SweepRecentSuccesses, SWEEP_INTERVAL_SECONDS)
+    end
+
+    _registered = true
+    ns.DebugPrint("UnitEventListener initialized")
+end
+
+function ns.UnitEventListener.Shutdown()
+    if not _registered then return end
+
+    if _sweepTimer and ns.Addon and ns.Addon.CancelTimer then
+        ns.Addon:CancelTimer(_sweepTimer)
+    end
+    _sweepTimer = nil
+
+    if ns.Addon then
+        ns.Addon:UnregisterEvent("PLAYER_ENTERING_WORLD")
+        ns.Addon:UnregisterEvent("GROUP_ROSTER_UPDATE")
+    end
+
+    if _frame then
+        _frame:UnregisterAllEvents()
+        _frame:SetScript("OnEvent", nil)
+    end
+
+    _trackedUnits = {}
+    _recentSuccesses = {}
+    _registered = false
+    ns.DebugPrint("UnitEventListener shut down")
+end
+
+function ns.UnitEventListener.IsActive()
+    return _registered
+end

--- a/DragonShout/Locales/enUS.lua
+++ b/DragonShout/Locales/enUS.lua
@@ -51,6 +51,10 @@ L["Player GUID"] = true
 L["Version"] = true
 L["Toggle debug mode on/off"] = true
 L["Debug mode: "] = true
+L["Combat-log listener"] = true
+L["Unit-event listener"] = true
+L["active"] = true
+L["inactive"] = true
 
 -- DragonShout/Core/MinimapIcon.lua
 L["Status: "] = true
@@ -61,6 +65,7 @@ L["Toggle on/off"] = true
 
 -- Default template strings (used as config defaults and locale keys)
 L["Interrupted {target}'s {extraSpell} with {spell}!"] = true
+L["Interrupted {target}'s {extraSpell}!"] = true
 L["CC'd {target} with {spell}!"] = true
 L["Dispelled {extraSpell} from {target}!"] = true
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Retail 12.0 (Midnight) marks `COMBAT_LOG_EVENT_UNFILTERED` with `HasRestrictions = true` (verified against Blizzard's published `BlizzardInterfaceCode/Interface/AddOns/Blizzard_APIDocumentationGenerated/CombatLogDocumentation.lua` lines 119-128), causing `ADDON_ACTION_FORBIDDEN` on insecure registration. This breaks DragonShout on retail 12.0+: interrupts, CC announcements, and dispels all stop working.

This is a one-PR full migration (not gate-only). The capability flag `ns.capabilities.combatLog` (set in `Lifecycle.Initialize`) now selects between two source modules:

- `CombatLogListener` (existing, Classic + pre-12.0 retail) registers `COMBAT_LOG_EVENT_UNFILTERED` and dispatches by subevent.
- `UnitEventListener` (new, retail 12.0+) registers `UNIT_SPELLCAST_INTERRUPTED`, `UNIT_AURA`, and `UNIT_SPELLCAST_SUCCEEDED` against tracked unit tokens (player + pet + party + raid).

Both source modules feed identical payload tables into the existing handlers (`OnInterrupt`, `OnAuraApplied`, `OnDispel`). Handler signatures refactored from positional CLEU args to a single payload table.

The aura cache (owned by `AuraListener`) supports dispel correlation: `UNIT_SPELLCAST_SUCCEEDED` for player dispel casts is bound to a target only when `UNIT_AURA` fires `removedAuraInstanceIDs` on a friendly unit within 600 ms.

## Capability gaps disclosed (retail 12.0+)

- Loss of ~50 yd CLEU global scope (unit-token scoped only).
- Interrupter's spell name no longer available in `UNIT_SPELLCAST_INTERRUPTED` payload (default `interrupts.template` adjusted to read sensibly without it).
- Hostile-source aura data may be redacted in instances (`AuraData.sourceUnit` nil).
- No `UNIT_DISPEL` event - dispel detection is inferential via cast + aura-removal correlation.

## Testing

- `mise exec -- luacheck .` passes (0 warnings / 0 errors in 31 files).
- **User must validate on live retail 12.0 before merge sign-off.**
- Trigger categories to test on retail 12.0+:
  - Interrupts: kick a target dummy or dungeon mob cast; observe announcement.
  - CC on player: get CC'd; observe announcement.
  - CC applied by player: CC a hostile target; observe announcement.
  - Dispels: cleanse a friendly group member with a dispelable debuff; observe announcement (with the dispelled aura name resolved from the cache).
- On Classic flavors (TBC Anniversary / MoP Classic): verify CLEU path still works unchanged.
- `/ds status`: should show `Combat-log listener: active` on Classic and `Unit-event listener: active` on retail 12.0+.

## Open questions worth user review

- 600 ms dispel correlation window is a chosen default; may need tuning under high latency.
- Default `interrupts.template` changed from `"Interrupted {target}'s {extraSpell} with {spell}!"` to `"Interrupted {target}'s {extraSpell}!"`. Existing user profiles untouched (no SavedVariables migration); only new profiles get the new default.

## Checklist

- [x] luacheck passes
- [x] Code review approved (with separate review of rebase conflict resolution)
- [x] Documentation updated (AGENTS.md gotcha #6 rewritten)
- [x] Architecture brief produced and followed
- [ ] User validation on live retail 12.0 (pending)

Closes #22