### PR TITLE
feat: add UnitEventListener for retail Midnight CLEU restrictions (#28)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -52,13 +52,14 @@ files["DragonShout/"] = {
     read_globals = {
         -- WoW API
         "IsInGroup", "IsInRaid", "IsInInstance",
-        "UnitGUID", "UnitDebuff", "C_UnitAuras",
+        "UnitGUID", "UnitName", "UnitDebuff", "C_UnitAuras",
         "CombatLogGetCurrentEventInfo",
         "SendChatMessage", "C_ChatInfo",
         "InCombatLockdown", "IsShiftKeyDown",
         "InterfaceOptionsFrame_OpenToCategory", "Settings",
         "hooksecurefunc",
         "GetSpellInfo", "C_Spell",
+        "GetBuildInfo", "C_RestrictedActions",
 
         -- WoW Globals
         "WOW_PROJECT_ID", "WOW_PROJECT_MAINLINE",

--- a/DragonShout/Core/Capabilities.lua
+++ b/DragonShout/Core/Capabilities.lua
@@ -1,0 +1,45 @@
+-------------------------------------------------------------------------------
+-- Capabilities.lua
+-- Client capability flags consulted by listener modules at Initialize time
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetBuildInfo = GetBuildInfo
+local WOW_PROJECT_ID = WOW_PROJECT_ID
+local WOW_PROJECT_MAINLINE = WOW_PROJECT_MAINLINE
+
+-------------------------------------------------------------------------------
+-- Detection
+--
+-- Retail patch 12.0 (Midnight) restricts COMBAT_LOG_EVENT_UNFILTERED for
+-- addons: the event registers without error but never fires, and
+-- CombatLogGetCurrentEventInfo() returns obfuscated values. C_RestrictedActions
+-- is the namespace Blizzard shipped for this purpose; the build-number
+-- comparison is a belt-and-braces guard. Both must hold for the restriction
+-- to apply.
+-------------------------------------------------------------------------------
+
+local function DetectCleuRestricted()
+    if C_RestrictedActions == nil then return false end
+    if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return false end
+    if not GetBuildInfo then return false end
+    local buildNumber = select(4, GetBuildInfo())
+    if type(buildNumber) ~= "number" then return false end
+    return buildNumber >= 120000
+end
+
+local cleuRestricted = DetectCleuRestricted()
+
+ns.capabilities = {
+    cleuRestricted = cleuRestricted,
+    -- A clean dispel source+target+spell signal exists on Classic via
+    -- SPELL_DISPEL; retail Midnight has no equivalent attribution event.
+    dispelAttribution = not cleuRestricted,
+}

--- a/DragonShout/Core/Init.lua
+++ b/DragonShout/Core/Init.lua
@@ -83,6 +83,7 @@ DragonShoutNS = ns
 
 local LISTENER_MODULES = {
     "CombatLogListener",
+    "UnitEventListener",
     "InterruptListener",
     "AuraListener",
     "DispelListener",

--- a/DragonShout/DragonShout.toc
+++ b/DragonShout/DragonShout.toc
@@ -29,6 +29,7 @@ Locales\zhTW.lua
 
 # Core
 Core\Init.lua
+Core\Capabilities.lua
 Core\Config.lua
 Core\Lifecycle.lua
 Core\ConfigWindow.lua
@@ -38,6 +39,7 @@ Core\MinimapIcon.lua
 
 # Listeners
 Listeners\CombatLogListener.lua
+Listeners\UnitEventListener.lua
 Listeners\InterruptListener.lua
 Listeners\AuraListener.lua
 Listeners\DispelListener.lua

--- a/DragonShout/Listeners/AuraListener.lua
+++ b/DragonShout/Listeners/AuraListener.lua
@@ -135,8 +135,25 @@ end
 
 ns.AuraListener = {}
 
-function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, destName, _, _)
-    local spellId, spellName, _, auraType = select(12, CombatLogGetCurrentEventInfo())
+-- Exposed so UnitEventListener (retail Midnight UNIT_AURA path) can filter
+-- updateInfo.addedAuras to CC spells before paying the cost of a full
+-- OnAuraApplied call. The handler still re-checks membership; this is a
+-- pre-filter, not a load-bearing gate.
+ns.AuraListener.CC_TYPE = CC_TYPE
+
+function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, destName, _, _, extras)
+    -- `extras` is the post-PR-#28 minimal signature extension: when present
+    -- (UnitEventListener on retail Midnight) spell info travels through it.
+    -- When nil (CombatLogListener on Classic), fall back to CLEU positional
+    -- arguments at index 12+.
+    local spellId, spellName, auraType
+    if extras then
+        spellId = extras.spellId
+        spellName = extras.spellName
+        auraType = extras.auraType
+    else
+        spellId, spellName, _, auraType = select(12, CombatLogGetCurrentEventInfo())
+    end
 
     ns.DebugPrint(string_format("AuraListener: auraType=%s spellId=%s", tostring(auraType), tostring(spellId)))
 

--- a/DragonShout/Listeners/CombatLogListener.lua
+++ b/DragonShout/Listeners/CombatLogListener.lua
@@ -66,11 +66,18 @@ local frame = CreateFrame("Frame")
 frame:SetScript("OnEvent", OnCombatLogEvent)
 
 function ns.CombatLogListener.Initialize(_addon)
+    if ns.capabilities and ns.capabilities.cleuRestricted then
+        ns.DebugPrint("CombatLogListener: CLEU restricted on this client; standing down")
+        return
+    end
     frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     ns.DebugPrint("CombatLogListener initialized")
 end
 
 function ns.CombatLogListener.Shutdown()
+    if ns.capabilities and ns.capabilities.cleuRestricted then
+        return
+    end
     frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     ns.DebugPrint("CombatLogListener shut down")
 end

--- a/DragonShout/Listeners/InterruptListener.lua
+++ b/DragonShout/Listeners/InterruptListener.lua
@@ -38,7 +38,7 @@ end
 
 ns.InterruptListener = {}
 
-function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destName, _, _)
+function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destName, _, _, extras)
     if not ns.playerGUID then
         ns.DebugPrint("InterruptListener: playerGUID is nil, skipping")
         return
@@ -49,8 +49,21 @@ function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destN
         return
     end
 
-    local spellId, spellName, _, extraSpellId = select(12, CombatLogGetCurrentEventInfo())
-    local extraSpellName = GetSpellName(extraSpellId)
+    -- `extras` is the post-PR-#28 minimal signature extension: when present
+    -- (UnitEventListener on retail Midnight), spell info travels through it
+    -- because CombatLogGetCurrentEventInfo() is not the source of truth.
+    -- When nil (CombatLogListener on Classic), fall back to CLEU positional
+    -- arguments at index 12+.
+    local spellId, spellName, extraSpellName
+    if extras then
+        spellId = extras.spellId
+        spellName = extras.spellName
+        extraSpellName = extras.extraSpellName
+    else
+        local extraSpellId
+        spellId, spellName, _, extraSpellId = select(12, CombatLogGetCurrentEventInfo())
+        extraSpellName = GetSpellName(extraSpellId)
+    end
 
     ns.Announcer.Announce("interrupts", spellId, {
         spell = spellName,

--- a/DragonShout/Listeners/UnitEventListener.lua
+++ b/DragonShout/Listeners/UnitEventListener.lua
@@ -1,0 +1,193 @@
+-------------------------------------------------------------------------------
+-- UnitEventListener.lua
+-- Retail Midnight (Interface 120000+) CLEU replacement via UNIT_* events
+--
+-- Acts as an Anti-Corrupt Layer: translates UNIT_SPELLCAST_INTERRUPTED and
+-- UNIT_AURA payloads into the CLEU-shaped positional tuple the existing
+-- handlers (InterruptListener, AuraListener) consume, plus a trailing
+-- `extras` table carrying spell info that would normally come from
+-- select(12, CombatLogGetCurrentEventInfo()).
+--
+-- Active only when ns.capabilities.cleuRestricted is true; no-ops on Classic.
+--
+-- Supported versions: Retail (12.0+). Inert on MoP Classic, TBC Anniversary.
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local CreateFrame = CreateFrame
+local UnitGUID = UnitGUID
+local UnitName = UnitName
+local GetSpellInfo = GetSpellInfo
+local C_Spell = C_Spell
+local string_format = string.format
+local tostring = tostring
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+local function GetSpellName(spellId)
+    if not spellId then return nil end
+    local name
+    if C_Spell and C_Spell.GetSpellName then
+        name = C_Spell.GetSpellName(spellId)
+    elseif GetSpellInfo then
+        name = GetSpellInfo(spellId)
+    end
+    return name or tostring(spellId)
+end
+
+-------------------------------------------------------------------------------
+-- Module
+-------------------------------------------------------------------------------
+
+ns.UnitEventListener = {}
+
+-------------------------------------------------------------------------------
+-- Event handlers
+-------------------------------------------------------------------------------
+
+-- UNIT_SPELLCAST_INTERRUPTED(unitTarget, castGUID, spellID, interruptedBy, castBarID)
+--
+-- We only announce the player's own interrupts (matches InterruptListener's
+-- existing sourceGUID == playerGUID filter). `interruptedBy` is a unit token
+-- ("player", "pet", "party1", ...), not a GUID - filter on the token directly.
+-- The ADR explicitly defers group interrupt attribution; we keep srcGUID as
+-- ns.playerGUID since the token resolves to the player.
+--
+-- Spell semantics on retail Midnight: UNIT_SPELLCAST_INTERRUPTED carries the
+-- *interrupted* spell ID, not the interrupter's. We pass spellId/spellName as
+-- nil and put the interrupted spell into extraSpellId/extraSpellName. The
+-- announcer template substitutes empty for the interrupter spell and shows the
+-- interrupted spell as {extraSpell}.
+local function OnUnitSpellcastInterrupted(unitTarget, _castGUID, spellID, interruptedBy)
+    if not ns.playerGUID then
+        ns.DebugPrint("UnitEventListener: playerGUID is nil, skipping interrupt")
+        return
+    end
+    if interruptedBy ~= "player" then
+        return
+    end
+
+    local sourceName = UnitName("player")
+    local destGUID = unitTarget and UnitGUID(unitTarget) or nil
+    local destName = (unitTarget and UnitName(unitTarget)) or "[Unknown]"
+
+    ns.InterruptListener.OnInterrupt(
+        ns.playerGUID, sourceName, nil, nil,
+        destGUID, destName, nil, nil,
+        {
+            spellId = nil,
+            spellName = nil,
+            extraSpellId = spellID,
+            extraSpellName = GetSpellName(spellID),
+        }
+    )
+
+    ns.DebugPrint(string_format(
+        "UnitEventListener: interrupt translated spellID=%s target=%s",
+        tostring(spellID), tostring(destName)))
+end
+
+-- UNIT_AURA(unit, updateInfo)
+--
+-- Only react to the player's own auras. ccApplied (CC the player lands on
+-- enemies) is intentionally dropped on retail Midnight: enemy unit tokens are
+-- populated unreliably and sourceUnit on AuraData is often nil/secret. See
+-- ADR-0002 for the decision and trade-offs.
+local function OnUnitAura(unit, updateInfo)
+    if unit ~= "player" then return end
+    if not updateInfo then return end
+    local addedAuras = updateInfo.addedAuras
+    if not addedAuras then return end
+    if not ns.playerGUID then return end
+
+    local ccTypeTable = ns.AuraListener and ns.AuraListener.CC_TYPE
+    if not ccTypeTable then return end
+
+    local playerName = UnitName("player")
+
+    for _, auraData in ipairs(addedAuras) do
+        if auraData and auraData.isHarmful and ccTypeTable[auraData.spellId] then
+            local sourceUnit = auraData.sourceUnit
+            local sourceGUID = sourceUnit and UnitGUID(sourceUnit) or nil
+            local sourceName = sourceUnit and UnitName(sourceUnit) or nil
+
+            ns.AuraListener.OnAuraApplied(
+                sourceGUID, sourceName, nil, nil,
+                ns.playerGUID, playerName, nil, nil,
+                {
+                    spellId = auraData.spellId,
+                    spellName = auraData.name,
+                    auraType = "DEBUFF",
+                }
+            )
+
+            ns.DebugPrint(string_format(
+                "UnitEventListener: CC-on-player translated spellId=%s",
+                tostring(auraData.spellId)))
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Event dispatch
+-------------------------------------------------------------------------------
+
+local DISPATCH = {
+    UNIT_SPELLCAST_INTERRUPTED = OnUnitSpellcastInterrupted,
+    UNIT_AURA = OnUnitAura,
+}
+
+local function OnEvent(_self, event, ...)
+    local handler = DISPATCH[event]
+    if not handler then return end
+    handler(...)
+end
+
+-------------------------------------------------------------------------------
+-- Private event frame
+--
+-- Unnamed CreateFrame mirrors CombatLogListener's PR #26 pattern: a private
+-- frame avoids the AceEvent shared dispatcher's taint surface. The frame MUST
+-- be unnamed; a name would re-introduce shared-global exposure.
+-------------------------------------------------------------------------------
+
+local frame = CreateFrame("Frame")
+frame:SetScript("OnEvent", OnEvent)
+
+function ns.UnitEventListener.Initialize(_addon)
+    if not (ns.capabilities and ns.capabilities.cleuRestricted) then
+        return
+    end
+
+    -- UNIT_SPELLCAST_INTERRUPTED fires with `unitTarget` = the unit whose
+    -- cast was interrupted (e.g. an enemy `nameplate2`, `boss1`, `target`).
+    -- We cannot filter on "player" here - that would limit to events where
+    -- the *player's own* cast was interrupted. Filter on interruptedBy in
+    -- the handler instead.
+    frame:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED")
+    -- UNIT_AURA we only care about for the player (ccOnYou). Unit-filter it
+    -- to avoid spurious dispatches.
+    frame:RegisterUnitEvent("UNIT_AURA", "player")
+
+    ns.DebugPrint("UnitEventListener initialized (retail Midnight CLEU replacement)")
+    ns.DebugPrint(
+        "UnitEventListener: dispel announcements unavailable on retail Midnight - no attribution event")
+    ns.DebugPrint(
+        "UnitEventListener: ccApplied (CC on others) unavailable on retail Midnight - unreliable source attribution")
+end
+
+function ns.UnitEventListener.Shutdown()
+    if not (ns.capabilities and ns.capabilities.cleuRestricted) then
+        return
+    end
+    frame:UnregisterEvent("UNIT_SPELLCAST_INTERRUPTED")
+    frame:UnregisterEvent("UNIT_AURA")
+    ns.DebugPrint("UnitEventListener shut down")
+end


### PR DESCRIPTION
Closes #28. Implements the migration design specified in `.deliverables/tech-lead/ADR-0002-dragonshout-midnight-unit-events.md`.

## Why

On retail Midnight (Interface 120000+), `COMBAT_LOG_EVENT_UNFILTERED` is no longer available to addons (per [Blizzard's October 2025 announcement](https://news.blizzard.com/en-us/article/24244638) and [Ion Hazzikostas's combat addon disarmament post](https://worldofwarcraft.blizzard.com/en-us/news/24246290)). PR #26 silences the resulting `ADDON_ACTION_FORBIDDEN` error on retail and remains fully functional on Classic flavors, but does not restore retail combat announcements. This PR adds the actual functional replacement.

## What

- New `Core/Capabilities.lua` exposes `ns.capabilities.cleuRestricted` (and `dispelAttribution`). Set once at load time, gated on `C_RestrictedActions ~= nil AND WOW_PROJECT_ID == WOW_PROJECT_MAINLINE AND build >= 120000`.
- New `Listeners/UnitEventListener.lua` uses a private unnamed `CreateFrame("Frame")` (consistent with ADR-0001 / PR #26) to register `UNIT_SPELLCAST_INTERRUPTED` and `UNIT_AURA` on retail Midnight. Translates payloads into CLEU-shaped tuples plus an optional trailing `extras` table.
- `CombatLogListener.Initialize` / `Shutdown` self-gate on `cleuRestricted` so the two listeners are mutually exclusive without `Init.lua` knowing.
- `InterruptListener.OnInterrupt` and `AuraListener.OnAuraApplied` gain an optional trailing `extras` parameter. When absent (Classic CLEU path), behavior is byte-for-byte identical to pre-PR.

## Behavior matrix

| Flavor | CLEU | UnitEventListener | Interrupts | CC on player | Dispels |
|---|---|---|---|---|---|
| Retail Midnight 12.0+ | unavailable | active | ✅ (degraded interrupter-spell info) | ✅ | ❌ (dropped) |
| MoP Classic 5.5.3 | active | dormant | ✅ unchanged | ✅ unchanged | ✅ unchanged |
| TBC Anniversary 2.5.5 | active | dormant | ✅ unchanged | ✅ unchanged | ✅ unchanged |

## Retail Midnight degraded behaviors (intentional)

- **Interrupter's spell unavailable.** `UNIT_SPELLCAST_INTERRUPTED` payload contains only the interrupted spell, not the interrupter's spell. The announcement template now reads "Interrupted Boss's Fireball" rather than "Interrupted Boss's Fireball with Kick".
- **CC-on-other-players dropped.** Enemy-unit `UNIT_AURA` source attribution is unreliable in restriction windows. Only `unit == "player"` CC is announced on retail.
- **Dispel announcements dropped.** No combination of UNIT_* events provides reliable dispeller -> dispelled-spell attribution; Blizzard's `RAID_PLAYER_DISPELLABLE` filter and `GetAuraDispelTypeColor` signal intent toward display rather than attribution. One-shot DebugPrint at Initialize on retail explaining the gap.

## Stacked PR

This is stacked on top of #26. Once #26 merges, this branch will be rebased onto master.

## Verification

- `luacheck .` - 0 warnings, 0 errors in 32 files.
- Code review by automated reviewer passed APPROVE on commit `39f5bff` after a BLOCKER fix (interrupter filter switched from incorrect GUID compare to correct unit-token compare).

## Out of scope

- AceEvent removal (#27).
- Restoring dispel attribution on retail (no clean API).
- Group-interrupt attribution (deferred per ADR).
- Refactoring announcer module.