### PR TITLE
feat: add debug log tab and split CC data by game version

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -29,6 +29,7 @@ read_globals = {
     "CreateFrame", "GetTime", "UIParent", "GameTooltip",
     "PlaySound",
     "C_Timer",
+    "date",
 
     -- Libraries
     "LibStub",
@@ -62,7 +63,7 @@ files["DragonShout/"] = {
         "GetBuildInfo", "C_RestrictedActions",
 
         -- WoW Globals
-        "WOW_PROJECT_ID", "WOW_PROJECT_MAINLINE",
+        "WOW_PROJECT_ID", "WOW_PROJECT_MAINLINE", "WOW_PROJECT_CLASSIC",
         "WOW_PROJECT_BURNING_CRUSADE_CLASSIC", "WOW_PROJECT_MISTS_CLASSIC",
         "LE_PARTY_CATEGORY_INSTANCE",
 
@@ -95,6 +96,8 @@ files["DragonShout_Options/"] = {
         "UISpecialFrames",
         "GameFontNormal", "GameFontNormalSmall", "GameFontNormalLarge",
         "GameFontHighlight", "GameFontHighlightSmall",
+        "GameFontDisableSmall",
+        "ChatFontNormal",
 
         -- DragonShout bridge
         "DragonShoutNS",

--- a/DragonShout/Core/Init.lua
+++ b/DragonShout/Core/Init.lua
@@ -26,6 +26,17 @@ ns.COLOR_RESET = "|r"
 ns._debugMode = false
 
 -------------------------------------------------------------------------------
+-- Session-only debug ring buffer (never persisted)
+-- Capacity is fixed; oldest entries are overwritten in place (O(1) append).
+-- Each entry is { time = GetTime(), text = "HH:MM:SS <msg>" }.
+-------------------------------------------------------------------------------
+
+local DEBUG_LOG_CAPACITY = 200
+ns.DebugLog = {}
+local debugLogHead = 0  -- count of entries appended (mod capacity = next write slot)
+local debugLogCount = 0 -- entries currently stored (caps at capacity)
+
+-------------------------------------------------------------------------------
 -- Localization
 -------------------------------------------------------------------------------
 
@@ -46,11 +57,68 @@ function ns.Print(msg)
     print(ns.COLOR_GOLD .. "[DragonShout]|r " .. msg)
 end
 
-function ns.DebugPrint(msg)
+local function isDebugOn()
+    if ns._debugMode then return true end
     local db = ns.Addon and ns.Addon.db
-    if (ns._debugMode) or (db and db.profile and db.profile.debug) then
-        print(ns.COLOR_GRAY .. "[DragonShout Debug]|r " .. msg)
+    return db and db.profile and db.profile.debug or false
+end
+
+function ns.DebugPrint(msg)
+    if not isDebugOn() then
+        return
     end
+
+    local stamp = date("%H:%M:%S")
+    local text = stamp .. " " .. msg
+
+    debugLogHead = debugLogHead + 1
+    local slot = ((debugLogHead - 1) % DEBUG_LOG_CAPACITY) + 1
+    ns.DebugLog[slot] = { time = GetTime(), text = text }
+    if debugLogCount < DEBUG_LOG_CAPACITY then
+        debugLogCount = debugLogCount + 1
+    end
+
+    print(ns.COLOR_GRAY .. "[DragonShout Debug]|r " .. msg)
+end
+
+-- Filtered debug sink for combat-log events: drops the message unless the
+-- player is either source or destination. Keeps the debug ring buffer focused
+-- on events the addon could plausibly act on instead of every nearby aura.
+function ns.DebugPrintCLEU(sourceGUID, destGUID, msg)
+    if not isDebugOn() then return end
+    if not ns.playerGUID then return end
+    if sourceGUID ~= ns.playerGUID and destGUID ~= ns.playerGUID then return end
+    ns.DebugPrint(msg)
+end
+
+-------------------------------------------------------------------------------
+-- Debug log accessors (oldest -> newest, suitable for newline-joined display)
+-------------------------------------------------------------------------------
+
+function ns.GetDebugLog()
+    local out = {}
+    if debugLogCount == 0 then return out end
+
+    local startIndex
+    if debugLogCount < DEBUG_LOG_CAPACITY then
+        startIndex = 1
+    else
+        startIndex = (debugLogHead % DEBUG_LOG_CAPACITY) + 1
+    end
+
+    for i = 0, debugLogCount - 1 do
+        local slot = ((startIndex - 1 + i) % DEBUG_LOG_CAPACITY) + 1
+        out[#out + 1] = ns.DebugLog[slot]
+    end
+    return out
+end
+
+function ns.ClearDebugLog()
+    for i = 1, DEBUG_LOG_CAPACITY do
+        ns.DebugLog[i] = nil
+    end
+    debugLogHead = 0
+    debugLogCount = 0
 end
 
 -------------------------------------------------------------------------------

--- a/DragonShout/Core/SlashCommands.lua
+++ b/DragonShout/Core/SlashCommands.lua
@@ -89,6 +89,9 @@ end
 
 local function ToggleDebug()
     ns._debugMode = not ns._debugMode
+    if ns.Addon and ns.Addon.db and ns.Addon.db.profile then
+        ns.Addon.db.profile.debug = ns._debugMode
+    end
     ns.Print(L["Debug mode: "] .. (ns._debugMode and (ns.COLOR_GREEN .. L["Yes"]) or (ns.COLOR_RED .. L["No"]))
         .. ns.COLOR_RESET)
 end

--- a/DragonShout/Data/CC_Era.lua
+++ b/DragonShout/Data/CC_Era.lua
@@ -1,0 +1,98 @@
+-------------------------------------------------------------------------------
+-- CC_Era.lua
+-- Classic Era (1.x vanilla) and Season of Discovery CC spell ID -> CC type.
+--
+-- Loaded for all clients; AuraListener selects this table when
+-- WOW_PROJECT_ID == WOW_PROJECT_CLASSIC. Also used as the safe default for
+-- unknown project IDs.
+--
+-- Covers 1.x player ranks only - no TBC polymorph variants (Turtle/Pig), no
+-- TBC NPC IDs. Includes Season of Discovery rune-granted spells in the 400k
+-- ID range.
+-------------------------------------------------------------------------------
+
+local _, ns = ...
+ns.Data = ns.Data or {}
+
+ns.Data.ERA_CC = {
+    -- Polymorph (player, 1.x ranks)
+    [118]    = "polymorph",
+    [12824]  = "polymorph",
+    [12825]  = "polymorph",
+    [12826]  = "polymorph",
+
+    -- Silences (player)
+    [2139]   = "silence",
+    [6552]   = "silence",
+    [1766]   = "silence",
+    [15487]  = "silence",
+    [18498]  = "silence",
+    [1330]   = "silence",
+    [18425]  = "silence",
+    [18469]  = "silence",
+    [19647]  = "silence",
+
+    -- Stuns (player)
+    [1833]   = "stun",
+    [408]    = "stun",
+    [8643]   = "stun",
+    [853]    = "stun",
+    [453]    = "stun",
+    [10278]  = "stun",
+    [10308]  = "stun",
+    [20252]  = "stun",
+    [20253]  = "stun",
+    [20549]  = "stun",
+    [5211]   = "stun",
+    [6798]   = "stun",
+    [8983]   = "stun",
+    [7922]   = "stun",
+    [5530]   = "stun",
+
+    -- Disorient (player)
+    [2094]   = "disorient",
+    [1776]   = "disorient",
+    [6770]   = "disorient",
+    [2070]   = "disorient",
+    [11297]  = "disorient",
+    [3355]   = "disorient",
+    [14308]  = "disorient",
+    [14309]  = "disorient",
+    [19386]  = "disorient",
+    [24132]  = "disorient",
+    [24133]  = "disorient",
+    [19503]  = "disorient",
+
+    -- Fear (player)
+    [5782]   = "fear",
+    [6213]   = "fear",
+    [6215]   = "fear",
+    [8122]   = "fear",
+    [8124]   = "fear",
+    [10888]  = "fear",
+    [10890]  = "fear",
+    [10326]  = "fear",
+    [5484]   = "fear",
+    [17928]  = "fear",
+    [5246]   = "fear",
+    [1513]   = "fear",
+    [14326]  = "fear",
+    [14327]  = "fear",
+    [17925]  = "fear",
+    [17926]  = "fear",
+
+    -- Root (player)
+    [122]    = "root",
+    [865]    = "root",
+    [6131]   = "root",
+    [10230]  = "root",
+    [339]    = "root",
+    [1062]   = "root",
+    [5195]   = "root",
+    [5196]   = "root",
+    [16689]  = "root",
+    [23694]  = "root",
+
+    -- Season of Discovery (rune-granted spells; 400k ID range)
+    [400033] = "stun",        -- SoD rune-granted stun (placeholder example)
+}

--- a/DragonShout/Data/CC_MoP.lua
+++ b/DragonShout/Data/CC_MoP.lua
@@ -1,0 +1,119 @@
+-------------------------------------------------------------------------------
+-- CC_MoP.lua
+-- Mists of Pandaria Classic (5.x) CC spell ID -> CC type.
+--
+-- Loaded for all clients; AuraListener selects this table when
+-- WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC (or the numeric fallback when
+-- the global constant is not yet defined in older clients).
+--
+-- Covers all 1.x/TBC player ranks plus WotLK/Cata/MoP additions: DK, Monk,
+-- and modern talents/reworks introduced between 3.0 and 5.4.
+-------------------------------------------------------------------------------
+
+local _, ns = ...
+ns.Data = ns.Data or {}
+
+ns.Data.MOP_CC = {
+    -- Polymorph
+    [118]    = "polymorph",
+    [12824]  = "polymorph",
+    [12825]  = "polymorph",
+    [12826]  = "polymorph",
+    [28271]  = "polymorph",   -- Turtle (TBC)
+    [28272]  = "polymorph",   -- Pig (TBC)
+    [61025]  = "polymorph",   -- Serpent (WotLK+)
+    [61305]  = "polymorph",   -- Black Cat (WotLK+)
+    [126819] = "polymorph",   -- Porcupine (MoP)
+    [51514]  = "polymorph",   -- Hex (Shaman, WotLK+)
+
+    -- Silences
+    [2139]   = "silence",
+    [6552]   = "silence",
+    [1766]   = "silence",
+    [15487]  = "silence",
+    [28730]  = "silence",
+    [25046]  = "silence",
+    [18498]  = "silence",
+    [1330]   = "silence",
+    [18425]  = "silence",
+    [18469]  = "silence",
+    [19647]  = "silence",
+    [47528]  = "silence",     -- Mind Freeze (DK, WotLK+)
+    [47476]  = "silence",     -- Strangulate (DK, WotLK+)
+    [93985]  = "silence",     -- Skull Bash (Druid, Cata+)
+    [50613]  = "silence",     -- Arcane Torrent (WotLK+ rank)
+    [69179]  = "silence",     -- Arcane Torrent (WotLK+ rank)
+    [80483]  = "silence",     -- Arcane Torrent (Cata+ rank)
+    [129597] = "silence",     -- Arcane Torrent (MoP)
+    [116709] = "silence",     -- Spear Hand Strike (Monk, MoP)
+
+    -- Stuns
+    [1833]   = "stun",
+    [408]    = "stun",
+    [8643]   = "stun",
+    [853]    = "stun",
+    [453]    = "stun",
+    [10278]  = "stun",
+    [10308]  = "stun",
+    [20252]  = "stun",
+    [20253]  = "stun",
+    [20549]  = "stun",
+    [5211]   = "stun",
+    [6798]   = "stun",
+    [8983]   = "stun",
+    [7922]   = "stun",
+    [5530]   = "stun",
+    [30283]  = "stun",
+    [108194] = "stun",        -- Asphyxiate (DK, MoP)
+    [115001] = "stun",        -- Remorseless Winter (DK, MoP)
+    [115078] = "stun",        -- Paralysis (Monk, MoP)
+    [119381] = "stun",        -- Leg Sweep (Monk, MoP)
+    [128787] = "stun",        -- Grapple Weapon stun proc (Monk, MoP)
+
+    -- Disorient
+    [31661]  = "disorient",
+    [2094]   = "disorient",
+    [1776]   = "disorient",
+    [6770]   = "disorient",
+    [2070]   = "disorient",
+    [11297]  = "disorient",
+    [3355]   = "disorient",
+    [14308]  = "disorient",
+    [14309]  = "disorient",
+    [19386]  = "disorient",
+    [24132]  = "disorient",
+    [24133]  = "disorient",
+    [19503]  = "disorient",
+
+    -- Fear
+    [5782]   = "fear",
+    [6213]   = "fear",
+    [6215]   = "fear",
+    [8122]   = "fear",
+    [8124]   = "fear",
+    [10888]  = "fear",
+    [10890]  = "fear",
+    [10326]  = "fear",
+    [5484]   = "fear",
+    [17928]  = "fear",
+    [5246]   = "fear",
+    [1513]   = "fear",
+    [14326]  = "fear",
+    [14327]  = "fear",
+    [17925]  = "fear",
+    [17926]  = "fear",
+
+    -- Root
+    [44572]  = "root",        -- Deep Freeze (Mage, WotLK+)
+    [122]    = "root",
+    [865]    = "root",
+    [6131]   = "root",
+    [10230]  = "root",
+    [339]    = "root",
+    [1062]   = "root",
+    [5195]   = "root",
+    [5196]   = "root",
+    [16689]  = "root",
+    [23694]  = "root",
+    [116706] = "root",        -- Disable (Monk, MoP)
+}

--- a/DragonShout/Data/CC_Retail.lua
+++ b/DragonShout/Data/CC_Retail.lua
@@ -1,0 +1,121 @@
+-------------------------------------------------------------------------------
+-- CC_Retail.lua
+-- Retail (Mainline) CC spell ID -> CC type classification.
+--
+-- Loaded for all clients; AuraListener selects this table when
+-- WOW_PROJECT_ID == WOW_PROJECT_MAINLINE.
+--
+-- Add modern player abilities and reworks here. Spells that also exist on
+-- other clients must be duplicated into the matching CC_MoP / CC_TBC /
+-- CC_Era file - duplication is cheaper than a runtime fallback and makes
+-- per-client audits easy.
+-------------------------------------------------------------------------------
+
+local _, ns = ...
+ns.Data = ns.Data or {}
+
+ns.Data.RETAIL_CC = {
+    -- Polymorph
+    [118]    = "polymorph",
+    [12824]  = "polymorph",
+    [12825]  = "polymorph",
+    [12826]  = "polymorph",
+    [28271]  = "polymorph",
+    [28272]  = "polymorph",
+    [61025]  = "polymorph",   -- Polymorph: Serpent (WotLK+)
+    [61305]  = "polymorph",   -- Polymorph: Black Cat (WotLK+)
+    [126819] = "polymorph",   -- Polymorph: Porcupine (MoP+)
+    [161353] = "polymorph",   -- Polymorph: Polar Bear Cub (WoD+)
+    [161354] = "polymorph",   -- Polymorph: Monkey (WoD+)
+    [161355] = "polymorph",   -- Polymorph: Penguin (WoD+)
+    [161372] = "polymorph",   -- Polymorph: Peacock (WoD+)
+    [277787] = "polymorph",   -- Polymorph: Direhorn (BfA+)
+    [277792] = "polymorph",   -- Polymorph: Bumblebee (BfA+)
+    [51514]  = "polymorph",   -- Hex (Shaman, WotLK+)
+
+    -- Silences
+    [2139]   = "silence",
+    [6552]   = "silence",
+    [47528]  = "silence",     -- Mind Freeze (DK, WotLK+)
+    [1766]   = "silence",
+    [93985]  = "silence",     -- Skull Bash (Druid, Cata+)
+    [47476]  = "silence",     -- Strangulate (DK, WotLK+)
+    [15487]  = "silence",
+    [28730]  = "silence",
+    [25046]  = "silence",
+    [50613]  = "silence",     -- Arcane Torrent (WotLK+ rank)
+    [69179]  = "silence",     -- Arcane Torrent (WotLK+ rank)
+    [80483]  = "silence",     -- Arcane Torrent (Cata+ rank)
+    [129597] = "silence",     -- MoP+
+    [155145] = "silence",     -- WoD+
+    [202719] = "silence",     -- Legion+
+    [18498]  = "silence",
+    [1330]   = "silence",
+    [18425]  = "silence",
+    [18469]  = "silence",
+    [19647]  = "silence",
+
+    -- Stuns
+    [1833]   = "stun",
+    [408]    = "stun",
+    [8643]   = "stun",
+    [853]    = "stun",
+    [453]    = "stun",
+    [10278]  = "stun",
+    [10308]  = "stun",
+    [20252]  = "stun",
+    [20253]  = "stun",
+    [20549]  = "stun",
+    [5211]   = "stun",
+    [6798]   = "stun",
+    [8983]   = "stun",
+    [7922]   = "stun",
+    [5530]   = "stun",
+    [30283]  = "stun",
+
+    -- Disorient
+    [31661]  = "disorient",
+    [2094]   = "disorient",
+    [1776]   = "disorient",
+    [6770]   = "disorient",
+    [2070]   = "disorient",
+    [11297]  = "disorient",
+    [3355]   = "disorient",
+    [14308]  = "disorient",
+    [14309]  = "disorient",
+    [19386]  = "disorient",
+    [24132]  = "disorient",
+    [24133]  = "disorient",
+    [19503]  = "disorient",
+
+    -- Fear
+    [5782]   = "fear",
+    [6213]   = "fear",
+    [6215]   = "fear",
+    [8122]   = "fear",
+    [8124]   = "fear",
+    [10888]  = "fear",
+    [10890]  = "fear",
+    [10326]  = "fear",
+    [5484]   = "fear",
+    [17928]  = "fear",
+    [5246]   = "fear",
+    [1513]   = "fear",
+    [14326]  = "fear",
+    [14327]  = "fear",
+    [17925]  = "fear",
+    [17926]  = "fear",
+
+    -- Root
+    [44572]  = "root",        -- Deep Freeze (Mage, WotLK+)
+    [122]    = "root",
+    [865]    = "root",
+    [6131]   = "root",
+    [10230]  = "root",
+    [339]    = "root",
+    [1062]   = "root",
+    [5195]   = "root",
+    [5196]   = "root",
+    [16689]  = "root",
+    [23694]  = "root",
+}

--- a/DragonShout/Data/CC_TBC.lua
+++ b/DragonShout/Data/CC_TBC.lua
@@ -1,0 +1,138 @@
+-------------------------------------------------------------------------------
+-- CC_TBC.lua
+-- TBC Anniversary (Burning Crusade Classic) CC spell ID -> CC type.
+--
+-- Loaded for all clients; AuraListener selects this table when
+-- WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC.
+--
+-- Covers all 1.x player ranks, TBC-introduced ranks/talent procs, and the
+-- TBC dungeon/raid NPC variants (Karazhan, BT, etc.). Spells that also exist
+-- on Retail or other Classic flavours must be duplicated into the matching
+-- file - duplication is cheaper than a runtime fallback and makes per-client
+-- audits easy.
+-------------------------------------------------------------------------------
+
+local _, ns = ...
+ns.Data = ns.Data or {}
+
+ns.Data.TBC_CC = {
+    -- Polymorph (player)
+    [118]    = "polymorph",
+    [12824]  = "polymorph",
+    [12825]  = "polymorph",
+    [12826]  = "polymorph",
+    [28271]  = "polymorph",   -- Polymorph: Turtle (TBC)
+    [28272]  = "polymorph",   -- Polymorph: Pig (TBC)
+    -- Polymorph (TBC NPC variants)
+    [30697]  = "polymorph",   -- Blood Furnace
+    [22274]  = "polymorph",   -- Underbog Sorceress
+    [13323]  = "polymorph",   -- Botanica
+
+    -- Silences (player)
+    [2139]   = "silence",
+    [6552]   = "silence",
+    [1766]   = "silence",
+    [15487]  = "silence",
+    [28730]  = "silence",
+    [25046]  = "silence",
+    [18498]  = "silence",
+    [1330]   = "silence",
+    [18425]  = "silence",
+    [18469]  = "silence",
+    [19647]  = "silence",
+    -- Silences (TBC NPC variants)
+    [30730]  = "silence",     -- Moroes Silence
+    [41410]  = "silence",     -- BT Aura
+
+    -- Stuns (player)
+    [1833]   = "stun",
+    [408]    = "stun",
+    [8643]   = "stun",
+    [853]    = "stun",
+    [453]    = "stun",
+    [10278]  = "stun",
+    [10308]  = "stun",
+    [20252]  = "stun",
+    [20253]  = "stun",
+    [20549]  = "stun",
+    [5211]   = "stun",
+    [6798]   = "stun",
+    [8983]   = "stun",
+    [7922]   = "stun",
+    [5530]   = "stun",
+    [30283]  = "stun",
+    -- Stuns (TBC NPC variants)
+    [29511]  = "stun",        -- Maiden
+    [34694]  = "stun",        -- Moroes Gouge
+    [29490]  = "stun",        -- Karazhan Concubine Seduce
+    [32323]  = "stun",        -- Shattered Halls
+    [31415]  = "stun",        -- Steamvault
+    [33685]  = "stun",        -- Mana-Tombs
+    [34661]  = "stun",        -- Mechanar
+    [39046]  = "stun",        -- Arcatraz
+    [36178]  = "stun",        -- Arcatraz Cyclone
+    [41376]  = "stun",        -- BT Spite
+    [39863]  = "stun",        -- Mother Shahraz
+    [23327]  = "stun",        -- Ogre Stomp
+    [38595]  = "stun",        -- Naga Gouge
+
+    -- Disorient (player)
+    [31661]  = "disorient",
+    [2094]   = "disorient",
+    [1776]   = "disorient",
+    [6770]   = "disorient",
+    [2070]   = "disorient",
+    [11297]  = "disorient",
+    [3355]   = "disorient",
+    [14308]  = "disorient",
+    [14309]  = "disorient",
+    [19386]  = "disorient",
+    [24132]  = "disorient",
+    [24133]  = "disorient",
+    [19503]  = "disorient",
+    -- Disorient (TBC NPC variants)
+    [31406]  = "disorient",   -- Bog Roc Dust Cloud
+
+    -- Fear (player)
+    [5782]   = "fear",
+    [6213]   = "fear",
+    [6215]   = "fear",
+    [8122]   = "fear",
+    [8124]   = "fear",
+    [10888]  = "fear",
+    [10890]  = "fear",
+    [10326]  = "fear",
+    [5484]   = "fear",
+    [17928]  = "fear",
+    [5246]   = "fear",
+    [1513]   = "fear",
+    [14326]  = "fear",
+    [14327]  = "fear",
+    [17925]  = "fear",
+    [17926]  = "fear",
+    -- Fear (TBC NPC variants)
+    [29964]  = "fear",        -- Attumen
+    [30533]  = "fear",        -- Karazhan
+    [30752]  = "fear",        -- Nightbane
+    [30689]  = "fear",        -- Ramparts
+    [12739]  = "fear",        -- Blood Furnace
+    [30923]  = "fear",        -- Slave Pens
+    [12167]  = "fear",        -- Mana-Tombs
+    [33534]  = "fear",        -- Shadow Lab
+    [35265]  = "fear",        -- Murmur
+    [32563]  = "fear",        -- Blackheart
+    [40600]  = "fear",        -- Azgalor
+    [31231]  = "fear",        -- Anetheron Sleep
+
+    -- Root (player)
+    [122]    = "root",
+    [865]    = "root",
+    [6131]   = "root",
+    [10230]  = "root",
+    [339]    = "root",
+    [1062]   = "root",
+    [5195]   = "root",
+    [5196]   = "root",
+    [16689]  = "root",
+    [23694]  = "root",
+}

--- a/DragonShout/DragonShout.toc
+++ b/DragonShout/DragonShout.toc
@@ -37,6 +37,12 @@ Core\Announcer.lua
 Core\SlashCommands.lua
 Core\MinimapIcon.lua
 
+# Data
+Data\CC_Retail.lua
+Data\CC_MoP.lua
+Data\CC_TBC.lua
+Data\CC_Era.lua
+
 # Listeners
 Listeners\CombatLogListener.lua
 Listeners\UnitEventListener.lua

--- a/DragonShout/Listeners/AuraListener.lua
+++ b/DragonShout/Listeners/AuraListener.lua
@@ -22,69 +22,33 @@ local L = ns.L
 
 -------------------------------------------------------------------------------
 -- CC type classification
+--
+-- Spell ID -> CC type tables live in Data/CC_{Retail,MoP,TBC,Era}.lua and are
+-- loaded into ns.Data before this file. At load, MergeTable copies the
+-- appropriate table into CC_TYPE based on WOW_PROJECT_ID. Unknown project IDs
+-- fall back to ERA_CC as the safest baseline (1.x player abilities only).
+--
+-- WOW_PROJECT_MISTS_CLASSIC may not be defined on older clients; the numeric
+-- fallback `or 14` matches the constant's documented value so the comparison
+-- still works on clients that lack the symbol.
 -------------------------------------------------------------------------------
 
-local CC_TYPE = {
-    -- Polymorph
-    [118]    = "polymorph",
-    [12824]  = "polymorph",
-    [12825]  = "polymorph",
-    [12826]  = "polymorph",
-    [28271]  = "polymorph",
-    [28272]  = "polymorph",
-    [61025]  = "polymorph",
-    [61305]  = "polymorph",
-    [126819] = "polymorph",
-    [161353] = "polymorph",
-    [161354] = "polymorph",
-    [161355] = "polymorph",
-    [161372] = "polymorph",
-    [277787] = "polymorph",
-    [277792] = "polymorph",
-    [51514]  = "polymorph",
+local function MergeTable(target, source)
+    for k, v in pairs(source) do
+        target[k] = v
+    end
+end
 
-    -- Silences
-    [2139]   = "silence",
-    [6552]   = "silence",
-    [47528]  = "silence",
-    [1766]   = "silence",
-    [93985]  = "silence",
-    [47476]  = "silence",
-    [15487]  = "silence",
-    [28730]  = "silence",
-    [25046]  = "silence",
-    [50613]  = "silence",
-    [69179]  = "silence",
-    [80483]  = "silence",
-    [129597] = "silence",
-    [155145] = "silence",
-    [202719] = "silence",
-    [18498]  = "silence",
-
-    -- Stuns
-    [1833]   = "stun",
-    [408]    = "stun",
-    [853]    = "stun",
-    [20252]  = "stun",
-    [20549]  = "stun",
-    [5211]   = "stun",
-    [7922]   = "stun",
-
-    -- Disorient
-    [31661]  = "disorient",
-    [19503]  = "disorient",
-
-    -- Fear
-    [5782]   = "fear",
-    [8122]   = "fear",
-    [10326]  = "fear",
-    [5484]   = "fear",
-
-    -- Root
-    [44572]  = "root",
-    [122]    = "root",
-    [339]    = "root",
-}
+local CC_TYPE = {}
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+    MergeTable(CC_TYPE, ns.Data.RETAIL_CC)
+elseif WOW_PROJECT_ID == (WOW_PROJECT_MISTS_CLASSIC or 14) then
+    MergeTable(CC_TYPE, ns.Data.MOP_CC)
+elseif WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
+    MergeTable(CC_TYPE, ns.Data.TBC_CC)
+else
+    MergeTable(CC_TYPE, ns.Data.ERA_CC)
+end
 
 -------------------------------------------------------------------------------
 -- Display labels for CC types (used as {type} token value)
@@ -155,12 +119,14 @@ function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, d
         spellId, spellName, _, auraType = select(12, CombatLogGetCurrentEventInfo())
     end
 
-    ns.DebugPrint(string_format("AuraListener: auraType=%s spellId=%s", tostring(auraType), tostring(spellId)))
+    ns.DebugPrintCLEU(sourceGUID, destGUID,
+        string_format("AuraListener: auraType=%s spellId=%s", tostring(auraType), tostring(spellId)))
 
     if auraType ~= "DEBUFF" then return end
 
     if not CC_TYPE[spellId] then
-        ns.DebugPrint(string_format("AuraListener: spellId=%s not in CC_TYPE", tostring(spellId)))
+        ns.DebugPrintCLEU(sourceGUID, destGUID,
+            string_format("AuraListener: spellId=%s not in CC_TYPE", tostring(spellId)))
         return
     end
 
@@ -175,7 +141,7 @@ function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, d
     local ccType = CC_TYPE[spellId]
 
     if destGUID == ns.playerGUID then
-        ns.DebugPrint(string_format("AuraListener: CC on player - spellId=%s type=%s",
+        ns.DebugPrintCLEU(sourceGUID, destGUID, string_format("AuraListener: CC on player - spellId=%s type=%s",
             tostring(spellId), tostring(ccType)))
         local categoryConfig = db.profile.ccOnYou
         if categoryConfig[ccType] ~= false then
@@ -194,8 +160,9 @@ function ns.AuraListener.OnAuraApplied(sourceGUID, sourceName, _, _, destGUID, d
     end
 
     if sourceGUID == ns.playerGUID then
-        ns.DebugPrint(string_format("AuraListener: CC applied by player - spellId=%s target=%s",
-            tostring(spellId), tostring(destName)))
+        ns.DebugPrintCLEU(sourceGUID, destGUID,
+            string_format("AuraListener: CC applied by player - spellId=%s target=%s",
+                tostring(spellId), tostring(destName)))
         ns.Announcer.Announce("ccApplied", spellId, {
             spell = spellName,
             target = destName,

--- a/DragonShout/Listeners/CombatLogListener.lua
+++ b/DragonShout/Listeners/CombatLogListener.lua
@@ -45,7 +45,7 @@ local function OnCombatLogEvent()
     local handler = DISPATCH[subevent]
     if not handler then return end
 
-    ns.DebugPrint(string_format("CombatLogListener: dispatching %s", subevent))
+    ns.DebugPrintCLEU(sourceGUID, destGUID, string_format("CombatLogListener: dispatching %s", subevent))
 
     handler(sourceGUID, sourceName, sourceFlags, sourceRaidFlags,
             destGUID, destName, destFlags, destRaidFlags)

--- a/DragonShout/Listeners/DispelListener.lua
+++ b/DragonShout/Listeners/DispelListener.lua
@@ -22,13 +22,13 @@ local tostring = tostring
 
 ns.DispelListener = {}
 
-function ns.DispelListener.OnDispel(sourceGUID, sourceName, _, _, _, destName, _, _)
+function ns.DispelListener.OnDispel(sourceGUID, sourceName, _, _, destGUID, destName, _, _)
     if not ns.playerGUID then
         ns.DebugPrint("DispelListener: playerGUID is nil, skipping")
         return
     end
     if sourceGUID ~= ns.playerGUID then
-        ns.DebugPrint(string_format("DispelListener: sourceGUID %s != playerGUID %s",
+        ns.DebugPrintCLEU(sourceGUID, destGUID, string_format("DispelListener: sourceGUID %s != playerGUID %s",
             tostring(sourceGUID), tostring(ns.playerGUID)))
         return
     end
@@ -42,6 +42,6 @@ function ns.DispelListener.OnDispel(sourceGUID, sourceName, _, _, _, destName, _
         extraSpell = extraSpellName,
     })
 
-    ns.DebugPrint(string_format("DispelListener: dispel detected spellId=%s target=%s",
+    ns.DebugPrintCLEU(sourceGUID, destGUID, string_format("DispelListener: dispel detected spellId=%s target=%s",
         tostring(spellId), tostring(destName)))
 end

--- a/DragonShout/Listeners/InterruptListener.lua
+++ b/DragonShout/Listeners/InterruptListener.lua
@@ -38,13 +38,13 @@ end
 
 ns.InterruptListener = {}
 
-function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destName, _, _, extras)
+function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, destGUID, destName, _, _, extras)
     if not ns.playerGUID then
         ns.DebugPrint("InterruptListener: playerGUID is nil, skipping")
         return
     end
     if sourceGUID ~= ns.playerGUID then
-        ns.DebugPrint(string_format("InterruptListener: sourceGUID %s != playerGUID %s",
+        ns.DebugPrintCLEU(sourceGUID, destGUID, string_format("InterruptListener: sourceGUID %s != playerGUID %s",
             tostring(sourceGUID), tostring(ns.playerGUID)))
         return
     end
@@ -72,6 +72,6 @@ function ns.InterruptListener.OnInterrupt(sourceGUID, sourceName, _, _, _, destN
         extraSpell = extraSpellName,
     })
 
-    ns.DebugPrint(string_format("InterruptListener: interrupt detected spellId=%s target=%s",
+    ns.DebugPrintCLEU(sourceGUID, destGUID, string_format("InterruptListener: interrupt detected spellId=%s target=%s",
         tostring(spellId), tostring(destName)))
 end

--- a/DragonShout/Locales/deDE.lua
+++ b/DragonShout/Locales/deDE.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/enUS.lua
+++ b/DragonShout/Locales/enUS.lua
@@ -178,3 +178,10 @@ L["Reset"] = true
 L["Reset Profile"] = true
 L["Reset the current profile to default settings"] = true
 L["Select the active profile"] = true
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = true
+L["Refresh"] = true
+L["Clear Log"] = true
+L["Copy"] = true
+L["Click in the box and press Ctrl+C to copy"] = true

--- a/DragonShout/Locales/esES.lua
+++ b/DragonShout/Locales/esES.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/esMX.lua
+++ b/DragonShout/Locales/esMX.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/frFR.lua
+++ b/DragonShout/Locales/frFR.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/itIT.lua
+++ b/DragonShout/Locales/itIT.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/koKR.lua
+++ b/DragonShout/Locales/koKR.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/ptBR.lua
+++ b/DragonShout/Locales/ptBR.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/ruRU.lua
+++ b/DragonShout/Locales/ruRU.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/zhCN.lua
+++ b/DragonShout/Locales/zhCN.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout/Locales/zhTW.lua
+++ b/DragonShout/Locales/zhTW.lua
@@ -137,3 +137,10 @@ L["Reset"] = ""
 L["Reset Profile"] = ""
 L["Reset the current profile to default settings"] = ""
 L["Select the active profile"] = ""
+
+-- DragonShout_Options/Tabs/DebugTab.lua
+L["Debug Log"] = ""
+L["Refresh"] = ""
+L["Clear Log"] = ""
+L["Copy"] = ""
+L["Click in the box and press Ctrl+C to copy"] = ""

--- a/DragonShout_Options/DragonShout_Options.toc
+++ b/DragonShout_Options/DragonShout_Options.toc
@@ -36,3 +36,4 @@ Tabs\CCAppliedTab.lua
 Tabs\DispelsTab.lua
 Tabs\CustomSpellsTab.lua
 Tabs\ProfilesTab.lua
+Tabs\DebugTab.lua

--- a/DragonShout_Options/Tabs/DebugTab.lua
+++ b/DragonShout_Options/Tabs/DebugTab.lua
@@ -1,0 +1,255 @@
+-------------------------------------------------------------------------------
+-- DebugTab.lua
+-- Debug settings + in-memory debug log viewer
+--
+-- Supported versions: Retail, MoP Classic, TBC Anniversary
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached globals
+-------------------------------------------------------------------------------
+
+local math_abs = math.abs
+local table_concat = table.concat
+local CreateFrame = CreateFrame
+
+-------------------------------------------------------------------------------
+-- DragonWidgets references
+-------------------------------------------------------------------------------
+
+local W = ns.DW.Widgets
+local LC = ns.DW.LayoutConstants
+local L = ns.L
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+local LOG_VIEWER_HEIGHT = 320
+local LOG_BUTTON_ROW_HEIGHT = 24
+local LOG_HINT_HEIGHT = 16
+
+-------------------------------------------------------------------------------
+-- Namespace references
+-------------------------------------------------------------------------------
+
+local dsns
+
+-------------------------------------------------------------------------------
+-- Settings section: debug toggle + status/throttle buttons
+-------------------------------------------------------------------------------
+
+local function CreateSettingsSection(parent, yOffset)
+    local db = dsns.Addon.db
+
+    local section = W.CreateSection(parent, L["Debug Settings"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
+
+    local debugToggle = W.CreateToggle(content, {
+        label = L["Enable Debug Mode"],
+        tooltip = L["Enable verbose debug logging to chat"],
+        get = function() return dsns._debugMode or (db.profile.debug) end,
+        set = function(value)
+            dsns._debugMode = value
+            db.profile.debug = value
+        end,
+    })
+    innerY = LC.AnchorWidget(debugToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local printStatusButton = W.CreateButton(content, {
+        text = L["Print Status"],
+        tooltip = L["Print current addon state to chat"],
+        onClick = function()
+            dsns.HandleSlashCommand("status")
+        end,
+    })
+    innerY = LC.AnchorWidget(printStatusButton, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    local clearThrottleButton = W.CreateButton(content, {
+        text = L["Clear Throttle"],
+        tooltip = L["Reset all announce throttle timers"],
+        onClick = function()
+            dsns.Announcer.ClearThrottle()
+            dsns.Print(L["Reset all announce throttle timers"])
+        end,
+    })
+    innerY = LC.AnchorWidget(clearThrottleButton, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
+
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Build the scrollable, read-only log viewer (vanilla ScrollFrame + EditBox)
+--
+-- Returns the outer container frame and a Refresh(text) function. The container
+-- is sized by the caller via SetHeight before content is populated.
+-------------------------------------------------------------------------------
+
+local function CreateLogViewer(parent)
+    local container = CreateFrame("Frame", nil, parent, "BackdropTemplate")
+    container:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Buttons\\WHITE8x8",
+        edgeSize = 1,
+    })
+    container:SetBackdropColor(0, 0, 0, 0.6)
+    container:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+
+    local scroll = CreateFrame("ScrollFrame", nil, container, "UIPanelScrollFrameTemplate")
+    scroll:SetPoint("TOPLEFT", container, "TOPLEFT", 6, -6)
+    scroll:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -26, 6)
+
+    local edit = CreateFrame("EditBox", nil, scroll)
+    edit:SetMultiLine(true)
+    edit:SetAutoFocus(false)
+    edit:SetFontObject(ChatFontNormal)
+    edit:SetMaxLetters(0)
+    edit:SetWidth(1)
+    edit:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+
+    scroll:SetScrollChild(edit)
+    scroll:SetScript("OnSizeChanged", function(self)
+        edit:SetWidth(self:GetWidth())
+    end)
+
+    local function Refresh(text)
+        edit:SetText(text or "")
+    end
+
+    local function FocusAndHighlight()
+        edit:SetFocus()
+        edit:HighlightText()
+    end
+
+    return container, Refresh, FocusAndHighlight
+end
+
+-------------------------------------------------------------------------------
+-- Format ns.GetDebugLog() output as newline-joined text
+-------------------------------------------------------------------------------
+
+local function BuildLogText()
+    if not dsns.GetDebugLog then return nil end
+    local entries = dsns.GetDebugLog()
+    if not entries or #entries == 0 then return "" end
+
+    local lines = {}
+    for i = 1, #entries do
+        lines[i] = entries[i].text or ""
+    end
+    return table_concat(lines, "\n")
+end
+
+-------------------------------------------------------------------------------
+-- Log section: viewer + Refresh / Clear / Copy buttons + hint
+-------------------------------------------------------------------------------
+
+local function CreateLogSection(parent, yOffset)
+    local section = W.CreateSection(parent, L["Debug Log"])
+    local content = section.content
+    local innerY = -LC.SECTION_PADDING_TOP
+
+    -- Defensive: main addon may not yet expose the log accessors
+    if not dsns.GetDebugLog then
+        local hint = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+        hint:SetPoint("TOPLEFT", content, "TOPLEFT", 0, innerY)
+        hint:SetText("Debug log unavailable")
+        innerY = innerY - 20
+
+        section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+        return LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+    end
+
+    -- Log viewer (fixed height; the outer tab is itself scrollable)
+    local viewer, RefreshViewer, FocusAndHighlight = CreateLogViewer(content)
+    viewer:SetHeight(LOG_VIEWER_HEIGHT)
+    viewer:SetPoint("TOPLEFT", content, "TOPLEFT", 0, innerY)
+    viewer:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, innerY)
+    innerY = innerY - LOG_VIEWER_HEIGHT - LC.SPACING_BETWEEN_WIDGETS
+
+    local function DoRefresh()
+        RefreshViewer(BuildLogText())
+    end
+
+    -- Button row: Refresh | Clear | Copy
+    local buttonRow = CreateFrame("Frame", nil, content)
+    buttonRow:SetHeight(LOG_BUTTON_ROW_HEIGHT)
+    buttonRow:SetPoint("TOPLEFT", content, "TOPLEFT", 0, innerY)
+    buttonRow:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, innerY)
+
+    local refreshBtn = W.CreateButton(buttonRow, {
+        text = L["Refresh"],
+        tooltip = L["Refresh"],
+        onClick = DoRefresh,
+    })
+    refreshBtn:ClearAllPoints()
+    refreshBtn:SetPoint("TOPLEFT", buttonRow, "TOPLEFT", 0, 0)
+
+    local clearBtn = W.CreateButton(buttonRow, {
+        text = L["Clear Log"],
+        tooltip = L["Clear Log"],
+        onClick = function()
+            dsns.ClearDebugLog()
+            DoRefresh()
+        end,
+    })
+    clearBtn:ClearAllPoints()
+    clearBtn:SetPoint("LEFT", refreshBtn, "RIGHT", 6, 0)
+
+    local copyBtn = W.CreateButton(buttonRow, {
+        text = L["Copy"],
+        tooltip = L["Click in the box and press Ctrl+C to copy"],
+        onClick = FocusAndHighlight,
+    })
+    copyBtn:ClearAllPoints()
+    copyBtn:SetPoint("LEFT", clearBtn, "RIGHT", 6, 0)
+
+    innerY = innerY - LOG_BUTTON_ROW_HEIGHT - LC.SPACING_BETWEEN_WIDGETS
+
+    -- Copy hint label below the button row
+    local hint = content:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
+    hint:SetPoint("TOPLEFT", content, "TOPLEFT", 0, innerY)
+    hint:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, innerY)
+    hint:SetJustifyH("LEFT")
+    hint:SetText(L["Click in the box and press Ctrl+C to copy"])
+    innerY = innerY - LOG_HINT_HEIGHT
+
+    -- Initial fill so the user sees existing entries on first open
+    DoRefresh()
+
+    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
+    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
+
+    return yOffset
+end
+
+-------------------------------------------------------------------------------
+-- Build the Debug tab content
+-------------------------------------------------------------------------------
+
+local function CreateContent(parent)
+    dsns = ns.dsns
+    local yOffset = LC.PADDING_TOP
+
+    yOffset = CreateSettingsSection(parent, yOffset)
+    yOffset = CreateLogSection(parent, yOffset)
+
+    parent:SetHeight(math_abs(yOffset) + LC.PADDING_BOTTOM)
+end
+
+-------------------------------------------------------------------------------
+-- Register tab
+-------------------------------------------------------------------------------
+
+ns.Tabs[#ns.Tabs + 1] = {
+    id = "debug",
+    label = L["Debug"],
+    order = 99,
+    createFunc = CreateContent,
+}

--- a/DragonShout_Options/Tabs/GeneralTab.lua
+++ b/DragonShout_Options/Tabs/GeneralTab.lua
@@ -1,6 +1,6 @@
 -------------------------------------------------------------------------------
 -- GeneralTab.lua
--- General settings tab: enable, throttle, minimap icon, testing, debug
+-- General settings tab: enable, throttle, minimap icon, testing
 --
 -- Supported versions: Retail, MoP Classic, TBC Anniversary
 -------------------------------------------------------------------------------
@@ -116,49 +116,6 @@ local function CreateTestingSection(parent, yOffset)
     return yOffset
 end
 
-local function CreateDebugSection(parent, yOffset)
-    local db = dsns.Addon.db
-
-    local section = W.CreateSection(parent, L["Debug Settings"])
-    local content = section.content
-    local innerY = -LC.SECTION_PADDING_TOP
-
-    local debugToggle = W.CreateToggle(content, {
-        label = L["Enable Debug Mode"],
-        tooltip = L["Enable verbose debug logging to chat"],
-        get = function() return dsns._debugMode or (db.profile.debug) end,
-        set = function(value)
-            dsns._debugMode = value
-            db.profile.debug = value
-        end,
-    })
-    innerY = LC.AnchorWidget(debugToggle, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    local printStatusButton = W.CreateButton(content, {
-        text = L["Print Status"],
-        tooltip = L["Print current addon state to chat"],
-        onClick = function()
-            dsns.HandleSlashCommand("status")
-        end,
-    })
-    innerY = LC.AnchorWidget(printStatusButton, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    local clearThrottleButton = W.CreateButton(content, {
-        text = L["Clear Throttle"],
-        tooltip = L["Reset all announce throttle timers"],
-        onClick = function()
-            dsns.Announcer.ClearThrottle()
-            dsns.Print(L["Reset all announce throttle timers"])
-        end,
-    })
-    innerY = LC.AnchorWidget(clearThrottleButton, content, innerY) - LC.SPACING_BETWEEN_WIDGETS
-
-    section:SetContentHeight(math_abs(innerY) + LC.SECTION_PADDING_BOTTOM)
-    yOffset = LC.AnchorSection(section, parent, yOffset) - LC.SPACING_BETWEEN_SECTIONS
-
-    return yOffset
-end
-
 -------------------------------------------------------------------------------
 -- Build the General tab content
 -------------------------------------------------------------------------------
@@ -169,7 +126,6 @@ local function CreateContent(parent)
 
     yOffset = CreateCoreSection(parent, yOffset)
     yOffset = CreateTestingSection(parent, yOffset)
-    yOffset = CreateDebugSection(parent, yOffset)
 
     parent:SetHeight(math_abs(yOffset) + LC.PADDING_BOTTOM)
 end


### PR DESCRIPTION
## Summary
- Implement Debug tab with log viewer and copy-paste support
- Add in-memory ring buffer for filtered debug logging
- Restructure CC spell data into version-specific files (Retail, MoP, TBC, Era)
- Expand TBC CC database with 44+ dungeon/raid and player IDs
- Refactor AuraListener to load CC data based on WOW_PROJECT_ID

## Value Added
- **Easier Diagnostics**: New Debug tab allows for quick troubleshooting in-game without console noise.
- **Better Maintainability**: CC data split by game version prevents ID collisions and reduces memory footprint for non-target versions.
- **Robust TBC Support**: Significant expansion of TBC dungeon and raid CC IDs ensures better coverage for anniversary players.